### PR TITLE
feat: add episode reflection card flow

### DIFF
--- a/src/netlify/functions/episodes.ts
+++ b/src/netlify/functions/episodes.ts
@@ -20,6 +20,16 @@ export interface MeetupEpisode {
   updated_at?: string;
 }
 
+export interface EpisodeCardContext extends MeetupEpisode {
+  meetup: {
+    id: number;
+    title: string;
+    description?: string;
+    default_theme?: string;
+    cover?: string;
+  };
+}
+
 export async function handler(
   event: NetlifyEvent,
   _context: NetlifyContext
@@ -29,6 +39,8 @@ export async function handler(
   try {
     const functionName = getFunctionNameFromEvent(event);
     switch (functionName) {
+      case 'getById':
+        return await handleGetById(event);
       case 'getByMeetupDate':
         return await handleGetByMeetupDate(event);
       case 'upsert':
@@ -40,6 +52,27 @@ export async function handler(
     console.error('Episodes handler error:', error);
     return createErrorResponse('服务器内部错误', 500);
   }
+}
+
+async function handleGetById(event: NetlifyEvent): Promise<NetlifyResponse> {
+  const { id } = getDataFromEvent(event);
+  if (!id) return createErrorResponse('缺少期次ID');
+
+  const { data, error } = await supabase
+    .from('meetup_episodes')
+    .select(
+      '*, meetup:meetups!meetup_episodes_meetup_id_fkey(id, title, description, default_theme, cover)'
+    )
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Get episode by id error:', error);
+    return createErrorResponse('查询失败', 500);
+  }
+  if (!data) return createErrorResponse('期次不存在', 404);
+
+  return createSuccessResponse({ episode: data });
 }
 
 // 获取某个循环活动在指定日期的期次信息

--- a/src/netlify/functions/episodes.ts
+++ b/src/netlify/functions/episodes.ts
@@ -13,7 +13,7 @@ export interface MeetupEpisode {
   id?: number;
   meetup_id: number;
   episode_number: number;
-  date: string; // YYYY-MM-DD
+  date: string; // YYYY-MM-DD, empty when the episode is not persisted yet
   theme?: string;
   description?: string;
   created_at?: string;
@@ -41,6 +41,8 @@ export async function handler(
     switch (functionName) {
       case 'getById':
         return await handleGetById(event);
+      case 'getByMeetupEpisode':
+        return await handleGetByMeetupEpisode(event);
       case 'getByMeetupDate':
         return await handleGetByMeetupDate(event);
       case 'upsert':
@@ -75,6 +77,50 @@ async function handleGetById(event: NetlifyEvent): Promise<NetlifyResponse> {
   return createSuccessResponse({ episode: data });
 }
 
+async function handleGetByMeetupEpisode(
+  event: NetlifyEvent
+): Promise<NetlifyResponse> {
+  const { meetup_id, episode_number } = getDataFromEvent(event);
+  if (!meetup_id || !episode_number) {
+    return createErrorResponse('缺少活动或期数');
+  }
+
+  const { data: meetup, error: meetupError } = await supabase
+    .from('meetups')
+    .select('id, title, description, default_theme, cover')
+    .eq('id', meetup_id)
+    .maybeSingle();
+
+  if (meetupError) {
+    console.error('Get meetup for episode card error:', meetupError);
+    return createErrorResponse('查询活动失败', 500);
+  }
+  if (!meetup) return createErrorResponse('活动不存在', 404);
+
+  const { data: episode, error: episodeError } = await supabase
+    .from('meetup_episodes')
+    .select('*')
+    .eq('meetup_id', meetup_id)
+    .eq('episode_number', episode_number)
+    .maybeSingle();
+
+  if (episodeError) {
+    console.error('Get episode by number error:', episodeError);
+    return createErrorResponse('查询期次失败', 500);
+  }
+
+  return createSuccessResponse({
+    episode: {
+      ...(episode || {
+        meetup_id: Number(meetup_id),
+        episode_number: Number(episode_number),
+        date: '',
+      }),
+      meetup,
+    } as EpisodeCardContext,
+  });
+}
+
 // 获取某个循环活动在指定日期的期次信息
 async function handleGetByMeetupDate(
   event: NetlifyEvent
@@ -98,7 +144,6 @@ async function handleUpsert(event: NetlifyEvent): Promise<NetlifyResponse> {
   const userId = await getUserIdFromAuth(event);
   if (!userId) return createErrorResponse('请先登录', 401);
 
-  // 校验 organizer 权限
   const { data: user } = await supabase
     .from('users')
     .select('role')

--- a/src/netlify/services/episodes.ts
+++ b/src/netlify/services/episodes.ts
@@ -9,6 +9,16 @@ export const episodesApi = {
     return http.get('/episodes', 'getById', { id });
   },
 
+  getByMeetupEpisode: async (
+    meetup_id: number,
+    episode_number: number
+  ): Promise<ApiResponse<{ episode: EpisodeCardContext }>> => {
+    return http.get('/episodes', 'getByMeetupEpisode', {
+      meetup_id,
+      episode_number,
+    });
+  },
+
   getByMeetupDate: async (
     meetup_id: number,
     date: string

--- a/src/netlify/services/episodes.ts
+++ b/src/netlify/services/episodes.ts
@@ -1,8 +1,14 @@
 import { ApiResponse } from '../types/http';
 import { http } from '../config/http';
-import { MeetupEpisode } from '../functions/episodes';
+import { EpisodeCardContext, MeetupEpisode } from '../functions/episodes';
 
 export const episodesApi = {
+  getById: async (
+    id: number
+  ): Promise<ApiResponse<{ episode: EpisodeCardContext }>> => {
+    return http.get('/episodes', 'getById', { id });
+  },
+
   getByMeetupDate: async (
     meetup_id: number,
     date: string

--- a/src/pages/card/CardCreate/index.tsx
+++ b/src/pages/card/CardCreate/index.tsx
@@ -107,11 +107,10 @@ const StandardCardCreate: React.FC = () => {
 
 const CreateCard: React.FC = () => {
   const [searchParams] = useSearchParams();
-  return searchParams.get('episodeId') ? (
-    <EpisodeCardCreate />
-  ) : (
-    <StandardCardCreate />
-  );
+  const hasEpisodeContext =
+    searchParams.has('episode') || searchParams.has('episodeId');
+
+  return hasEpisodeContext ? <EpisodeCardCreate /> : <StandardCardCreate />;
 };
 
 export default CreateCard;

--- a/src/pages/card/CardCreate/index.tsx
+++ b/src/pages/card/CardCreate/index.tsx
@@ -12,21 +12,14 @@ import EpisodeCardCreate from '../EpisodeCardCreate';
 import { getUserName } from '../../../utils';
 import { isMobileBrowser, saveImageDataUrl } from '@/utils/share';
 
-const CreateCard: React.FC = () => {
-  const [searchParams] = useSearchParams();
+const StandardCardCreate: React.FC = () => {
   const navigate = useNavigate();
   const showSnackbar = useGlobalSnackbar();
   const editFormRef = useRef<EditFormRef>(null);
 
-  if (searchParams.get('episodeId')) {
-    return <EpisodeCardCreate />;
-  }
-
-  // 初始卡片数据
   const getInitialCardData = (): CardItem => {
     const randomIndex = Math.floor(Math.random() * gradientOptions.length);
     const randomGradient = gradientOptions[randomIndex];
-
     const creator = getUserName() || '';
 
     return {
@@ -46,7 +39,6 @@ const CreateCard: React.FC = () => {
   const [initialCardData, setInitialCardData] =
     useState<CardItem>(getInitialCardData());
 
-  // 处理表单提交
   const handleSubmit = async (
     cardData: CardItem,
     imageData?: { customImage?: string; selectedSearchImage?: string }
@@ -59,14 +51,12 @@ const CreateCard: React.FC = () => {
       user_id: getUserId(),
     };
 
-    // 调用API提交卡片
     const response = await cardsApi.create(cardToSubmit);
 
     if (response.success) {
       showSnackbar.success(
         cardToSubmit.is_private ? '私密卡片已保存！' : '卡片提交成功！'
       );
-      // 重置表单
       setInitialCardData(getInitialCardData());
       setTimeout(
         () => navigate(cardToSubmit.is_private ? '/my-cards' : '/cards'),
@@ -77,20 +67,17 @@ const CreateCard: React.FC = () => {
     }
   };
 
-  // 下载卡片图片
   const handleDownload = async () => {
     const previewElement = editFormRef.current?.getPreviewElement();
     if (!previewElement) return;
 
-    // 找到预览中的卡片元素
     const cardElement = previewElement.querySelector('.card');
     if (!cardElement) {
       throw new Error('未找到卡片元素');
     }
 
-    // 配置html2canvas选项
     const canvas = await html2canvas(cardElement as HTMLElement, {
-      scale: 2, // 提高清晰度
+      scale: 2,
       useCORS: true,
       allowTaint: true,
       logging: false,
@@ -115,6 +102,15 @@ const CreateCard: React.FC = () => {
       onSubmit={handleSubmit}
       onDownload={handleDownload}
     />
+  );
+};
+
+const CreateCard: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  return searchParams.get('episodeId') ? (
+    <EpisodeCardCreate />
+  ) : (
+    <StandardCardCreate />
   );
 };
 

--- a/src/pages/card/CardCreate/index.tsx
+++ b/src/pages/card/CardCreate/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import html2canvas from 'html2canvas';
 
 import { CardItem } from '../../../netlify/types';
@@ -8,20 +8,26 @@ import { useGlobalSnackbar } from '@/context/app';
 import { getUserId } from '@/utils/user';
 import { gradientOptions } from '@/constants/gradient';
 import EditForm, { EditFormRef } from '../components/EditForm';
+import EpisodeCardCreate from '../EpisodeCardCreate';
 import { getUserName } from '../../../utils';
 import { isMobileBrowser, saveImageDataUrl } from '@/utils/share';
 
 const CreateCard: React.FC = () => {
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const showSnackbar = useGlobalSnackbar();
   const editFormRef = useRef<EditFormRef>(null);
+
+  if (searchParams.get('episodeId')) {
+    return <EpisodeCardCreate />;
+  }
 
   // 初始卡片数据
   const getInitialCardData = (): CardItem => {
     const randomIndex = Math.floor(Math.random() * gradientOptions.length);
     const randomGradient = gradientOptions[randomIndex];
 
-    let creator = getUserName() || '';
+    const creator = getUserName() || '';
 
     return {
       id: '',

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -132,7 +132,7 @@
   content: '';
   position: absolute;
   inset: 14px;
-  z-index: 3;
+  z-index: 4;
   border: 1px solid rgba(255, 255, 255, 0.34);
   border-radius: 20px;
   pointer-events: none;
@@ -140,7 +140,7 @@
 
 .cardWithPhoto {
   color: #fff;
-  background: #463a34;
+  background: #1f1b18;
 }
 
 .photoLayer {
@@ -149,41 +149,28 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  filter: brightness(0.84) saturate(0.94) contrast(0.98);
-  transform: scale(1.015);
+  filter: brightness(0.92) saturate(0.96);
+  transform: scale(1.01);
 }
 
 .photoContain .photoLayer {
   background-size: contain;
-  filter: brightness(0.9) saturate(0.96);
   transform: none;
+  background-color: #211d1a;
 }
 
 .overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    180deg,
-    rgba(20, 16, 13, 0.08),
-    rgba(20, 16, 13, 0.22) 48%,
-    rgba(20, 16, 13, 0.48)
-  );
-}
-
-.photoContain .overlay {
-  background: linear-gradient(
-    180deg,
-    rgba(20, 16, 13, 0.03),
-    rgba(20, 16, 13, 0.12) 55%,
-    rgba(20, 16, 13, 0.34)
-  );
+  background:
+    linear-gradient(180deg, rgba(8, 7, 6, 0.06) 0%, rgba(8, 7, 6, 0.05) 34%, rgba(8, 7, 6, 0.36) 72%, rgba(8, 7, 6, 0.56) 100%);
 }
 
 .cardContent {
   position: relative;
   z-index: 2;
   height: 100%;
-  padding: 40px 38px 28px;
+  padding: 36px 34px 26px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -191,7 +178,7 @@
 }
 
 .cardLongText .cardContent {
-  padding-top: 30px;
+  padding-top: 28px;
   gap: 12px;
 }
 
@@ -205,24 +192,12 @@
 }
 
 .cardWithPhoto .mainContent {
-  margin: 4px -4px 0;
-  padding: 18px 20px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 22px;
-  background: linear-gradient(
-    145deg,
-    rgba(24, 19, 16, 0.28),
-    rgba(24, 19, 16, 0.42)
-  );
-  box-shadow: 0 14px 34px rgba(20, 14, 10, 0.12);
-}
-
-.photoContain .mainContent {
-  background: linear-gradient(
-    145deg,
-    rgba(24, 19, 16, 0.34),
-    rgba(24, 19, 16, 0.48)
-  );
+  align-self: stretch;
+  padding: 22px 24px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(18, 15, 13, 0.58), rgba(18, 15, 13, 0.28));
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.16);
+  backdrop-filter: blur(2px);
 }
 
 .quote {
@@ -237,7 +212,10 @@
   line-height: 1.5;
   letter-spacing: 0.02em;
   text-wrap: pretty;
-  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.08);
+}
+
+.cardWithPhoto .quote {
+  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.32);
 }
 
 .quote::before {
@@ -256,33 +234,34 @@
 }
 
 .cardWithPhoto .quote::before {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.48);
 }
 
-.cardFooter {
+.signatureBar {
   flex: 0 0 auto;
-  min-height: 106px;
+  min-height: 88px;
+  padding: 12px 14px;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 94px;
-  align-items: end;
-  gap: 20px;
-  padding-top: 12px;
-  border-top: 1px solid rgba(96, 64, 45, 0.2);
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  border-radius: 20px;
+  background: rgba(255, 250, 245, 0.9);
+  color: #4a372d;
+  box-shadow: 0 12px 28px rgba(48, 31, 22, 0.12);
 }
 
-.cardWithPhoto .cardFooter {
-  border-top-color: rgba(255, 255, 255, 0.28);
+.cardWithPhoto .signatureBar {
+  background: rgba(255, 255, 255, 0.9);
 }
 
-.episodeInfo,
-.brandBlock {
-  align-self: center;
+.episodeInfo {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 5px;
-  font-size: 0.78rem;
-  line-height: 1.42;
+  gap: 4px;
+  font-size: 0.76rem;
+  line-height: 1.35;
 }
 
 .episodeInfo strong {
@@ -290,32 +269,78 @@
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
-  letter-spacing: 0.02em;
+  font-size: 0.88rem;
 }
 
-.episodeInfo span,
-.brandBlock span {
-  opacity: 0.78;
+.episodeInfo span {
+  opacity: 0.72;
 }
 
-.brandBlock strong {
-  font-size: 0.9rem;
-  letter-spacing: 0.12em;
+.episodeLabel {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: #f4dfd2;
+  color: #9d4f2f;
+  font-weight: 800;
+  letter-spacing: 0.04em;
 }
 
-.qrBlock {
-  width: 94px;
-  padding: 8px;
-  border-radius: 14px;
+.qrInline {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: #4a403a;
+}
+
+.qrInline svg,
+.inviteBadge svg {
+  flex: 0 0 auto;
+  padding: 4px;
+  border-radius: 10px;
   background: #fff;
-  color: #403a35;
+}
+
+.qrInline span {
+  width: 56px;
+  font-size: 0.62rem;
+  line-height: 1.35;
+}
+
+.inviteBadge {
+  flex: 0 0 auto;
+  align-self: center;
+  width: fit-content;
+  max-width: 100%;
+  padding: 10px 12px 10px 16px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border-radius: 999px;
+  background: rgba(255, 250, 245, 0.92);
+  color: #49372e;
+  box-shadow: 0 12px 30px rgba(48, 31, 22, 0.14);
+}
+
+.cardWithPhoto .inviteBadge {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.inviteCopy {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 5px;
-  font-size: 0.58rem;
-  text-align: center;
-  box-shadow: 0 8px 20px rgba(52, 34, 24, 0.14);
+  gap: 3px;
+  text-align: right;
+}
+
+.inviteCopy strong {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+}
+
+.inviteCopy span {
+  font-size: 0.68rem;
+  opacity: 0.72;
 }
 
 .actions {
@@ -344,24 +369,38 @@
   }
 
   .cardContent {
-    padding: 32px 26px 22px;
+    padding: 28px 22px 20px;
   }
 
   .cardLongText .cardContent {
-    padding-top: 24px;
+    padding-top: 22px;
+  }
+
+  .cardWithPhoto .mainContent {
+    padding: 18px;
   }
 
   .photoModes {
     grid-template-columns: 1fr;
   }
 
-  .cardFooter {
-    grid-template-columns: minmax(0, 1fr) 90px;
-    gap: 14px;
+  .signatureBar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 10px 11px;
   }
 
-  .qrBlock {
-    width: 90px;
+  .qrInline {
+    gap: 6px;
+  }
+
+  .qrInline span {
+    display: none;
+  }
+
+  .inviteBadge {
+    gap: 10px;
+    padding-left: 14px;
   }
 
   .actions {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -1,0 +1,192 @@
+.page {
+  min-height: calc(100vh - 64px);
+  padding: 40px 20px 64px;
+  display: grid;
+  grid-template-columns: minmax(0, 420px) minmax(320px, 520px);
+  justify-content: center;
+  gap: 48px;
+  background: #fffaf5;
+}
+
+.editor,
+.previewSection {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #d86f42;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.editor h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.12;
+}
+
+.description,
+.privacy {
+  margin: 0;
+  color: #6f675f;
+}
+
+.textarea {
+  min-height: 180px;
+  border: 1px solid #ded4c9;
+  border-radius: 18px;
+  padding: 18px;
+  font: inherit;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  resize: vertical;
+  background: white;
+}
+
+.textarea:focus {
+  outline: 3px solid rgba(255, 127, 80, 0.2);
+  border-color: #ff7f50;
+}
+
+.counter {
+  margin-top: -10px;
+  text-align: right;
+  color: #8d8379;
+  font-size: 0.85rem;
+}
+
+.photoButton,
+.removePhoto {
+  width: fit-content;
+  border: 0;
+  background: transparent;
+  color: #b85f39;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.settings {
+  display: flex;
+  flex-direction: column;
+  padding-top: 8px;
+  border-top: 1px solid #eadfd4;
+}
+
+.settings label {
+  display: flex;
+  align-items: center;
+  color: #514a44;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+  border-radius: 28px;
+  background: linear-gradient(145deg, #fff4dc, #f7c8aa 55%, #df8c6a);
+  box-shadow: 0 18px 50px rgba(87, 53, 36, 0.16);
+  background-size: cover;
+  background-position: center;
+}
+
+.cardWithPhoto {
+  color: #fff;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 13, 11, 0.28), rgba(15, 13, 11, 0.68));
+}
+
+.cardContent {
+  position: relative;
+  z-index: 1;
+  height: 100%;
+  padding: 42px 38px 28px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.quote {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: clamp(1.55rem, 4vw, 2.35rem);
+  font-weight: 650;
+  line-height: 1.55;
+  letter-spacing: 0.02em;
+}
+
+.cardFooter {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.episodeInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+  font-size: 0.83rem;
+  line-height: 1.35;
+}
+
+.episodeInfo span {
+  opacity: 0.84;
+}
+
+.qrBlock {
+  flex: 0 0 92px;
+  padding: 8px;
+  border-radius: 12px;
+  background: #fff;
+  color: #403a35;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.58rem;
+  text-align: center;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.state {
+  min-height: 60vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+@media (max-width: 820px) {
+  .page {
+    grid-template-columns: 1fr;
+    padding: 24px 16px 48px;
+    gap: 30px;
+  }
+
+  .previewSection {
+    width: min(100%, 520px);
+    margin: 0 auto;
+  }
+
+  .cardContent {
+    padding: 32px 26px 22px;
+  }
+
+  .actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -286,8 +286,9 @@
 
 .qrFloat {
   position: absolute;
-  right: 0;
-  bottom: 0;
+  right: -14px;
+  bottom: -14px;
+  z-index: 4;
   width: 70px;
   margin: 0;
   padding: 6px 6px 5px;
@@ -420,6 +421,8 @@
   }
 
   .qrFloat {
+    right: -10px;
+    bottom: -10px;
     width: 64px;
     padding: 5px 5px 4px;
   }

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -156,16 +156,6 @@
   box-shadow: 0 18px 50px rgba(87, 53, 36, 0.16);
 }
 
-.card::after {
-  content: '';
-  position: absolute;
-  inset: 14px;
-  z-index: 4;
-  border: 1px solid rgba(255, 255, 255, 0.34);
-  border-radius: 20px;
-  pointer-events: none;
-}
-
 .cardWithPhoto {
   color: #fff;
   background: #1f1b18;
@@ -177,7 +167,7 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  filter: brightness(0.92) saturate(0.96);
+  filter: brightness(0.96) saturate(0.98);
   transform: scale(1.01);
 }
 
@@ -190,24 +180,62 @@
 .overlay {
   position: absolute;
   inset: 0;
-  background:
-    linear-gradient(180deg, rgba(8, 7, 6, 0.06) 0%, rgba(8, 7, 6, 0.05) 34%, rgba(8, 7, 6, 0.36) 72%, rgba(8, 7, 6, 0.56) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(8, 7, 6, 0.03) 0%,
+    rgba(8, 7, 6, 0.04) 40%,
+    rgba(8, 7, 6, 0.16) 72%,
+    rgba(8, 7, 6, 0.26) 100%
+  );
 }
 
 .cardContent {
   position: relative;
   z-index: 2;
   height: 100%;
-  padding: 36px 34px 26px;
+  padding: 22px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 18px;
 }
 
-.cardLongText .cardContent {
-  padding-top: 28px;
-  gap: 12px;
+.topMeta {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.brandChip {
+  width: fit-content;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 250, 245, 0.86);
+  color: #8f4a2d;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  box-shadow: 0 8px 18px rgba(57, 37, 26, 0.08);
+}
+
+.cardWithPhoto .brandChip {
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.topMetaRight {
+  max-width: 55%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+  text-align: right;
+  font-size: 0.74rem;
+  line-height: 1.35;
+  color: rgba(82, 62, 51, 0.88);
+}
+
+.cardWithPhoto .topMetaRight {
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.28);
 }
 
 .mainContent {
@@ -215,24 +243,34 @@
   flex: 1 1 auto;
   overflow: hidden;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 14px;
+  align-items: center;
+  padding: 18px 86px 86px 0;
 }
 
-.cardWithPhoto .mainContent {
-  align-self: stretch;
-  padding: 22px 24px;
+.textPanel {
+  width: 100%;
+}
+
+.cardWithPhoto .textPanel {
+  width: min(100%, 88%);
+  padding: 20px 22px;
   border-radius: 24px;
-  background: linear-gradient(135deg, rgba(18, 15, 13, 0.58), rgba(18, 15, 13, 0.28));
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.16);
-  backdrop-filter: blur(2px);
+  background: linear-gradient(
+    135deg,
+    rgba(18, 15, 13, 0.54),
+    rgba(18, 15, 13, 0.2)
+  );
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.14);
+  backdrop-filter: blur(1.5px);
+}
+
+.cardLongText .textPanel {
+  padding-bottom: 18px;
 }
 
 .quote {
   position: relative;
   min-height: 0;
-  flex: 0 1 auto;
   overflow: hidden;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -244,16 +282,16 @@
 }
 
 .cardWithPhoto .quote {
-  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.32);
+  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.28);
 }
 
 .quote::before {
   content: '“';
   display: block;
   margin-bottom: -0.16em;
-  color: rgba(154, 73, 38, 0.36);
+  color: rgba(154, 73, 38, 0.3);
   font-family: Georgia, serif;
-  font-size: 1.55em;
+  font-size: 1.45em;
   font-weight: 400;
   line-height: 0.7;
 }
@@ -263,131 +301,49 @@
 }
 
 .cardWithPhoto .quote::before {
-  color: rgba(255, 255, 255, 0.48);
+  color: rgba(255, 255, 255, 0.44);
 }
 
 .byline {
-  flex: 0 0 auto;
-  align-self: flex-end;
+  margin-top: 16px;
   max-width: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.88rem;
+  font-size: 0.92rem;
   font-weight: 650;
-  letter-spacing: 0.06em;
-  opacity: 0.78;
+  letter-spacing: 0.05em;
+  color: rgba(79, 58, 47, 0.82);
 }
 
 .cardWithPhoto .byline {
-  opacity: 0.88;
-  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.28);
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.26);
 }
 
-.signatureBar {
-  flex: 0 0 auto;
-  min-height: 88px;
-  padding: 12px 14px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 16px;
-  border-radius: 20px;
-  background: rgba(255, 250, 245, 0.9);
-  color: #4a372d;
-  box-shadow: 0 12px 28px rgba(48, 31, 22, 0.12);
-}
-
-.cardWithPhoto .signatureBar {
-  background: rgba(255, 255, 255, 0.9);
-}
-
-.episodeInfo {
-  min-width: 0;
+.qrCorner {
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: 0.76rem;
-  line-height: 1.35;
-}
-
-.episodeInfo strong {
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  font-size: 0.88rem;
-}
-
-.episodeInfo span {
-  opacity: 0.72;
-}
-
-.episodeLabel {
-  width: fit-content;
-  padding: 3px 7px;
-  border-radius: 999px;
-  background: #f4dfd2;
-  color: #9d4f2f;
-  font-weight: 800;
-  letter-spacing: 0.04em;
-}
-
-.qrInline {
-  display: flex;
   align-items: center;
-  gap: 9px;
-  color: #4a403a;
+  gap: 5px;
+  padding: 8px 8px 6px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.94);
+  color: #4a372d;
+  box-shadow: 0 12px 28px rgba(48, 31, 22, 0.16);
 }
 
-.qrInline svg,
-.inviteBadge svg {
-  flex: 0 0 auto;
-  padding: 4px;
+.qrCorner svg {
   border-radius: 10px;
   background: #fff;
 }
 
-.qrInline span {
-  width: 56px;
-  font-size: 0.62rem;
-  line-height: 1.35;
-}
-
-.inviteBadge {
-  flex: 0 0 auto;
-  align-self: center;
-  width: fit-content;
-  max-width: 100%;
-  padding: 10px 12px 10px 16px;
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  border-radius: 999px;
-  background: rgba(255, 250, 245, 0.92);
-  color: #49372e;
-  box-shadow: 0 12px 30px rgba(48, 31, 22, 0.14);
-}
-
-.cardWithPhoto .inviteBadge {
-  background: rgba(255, 255, 255, 0.92);
-}
-
-.inviteCopy {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  text-align: right;
-}
-
-.inviteCopy strong {
-  font-size: 0.9rem;
-  letter-spacing: 0.08em;
-}
-
-.inviteCopy span {
-  font-size: 0.68rem;
-  opacity: 0.72;
+.qrCorner span {
+  font-size: 0.64rem;
+  line-height: 1.2;
 }
 
 .actions {
@@ -416,38 +372,36 @@
   }
 
   .cardContent {
-    padding: 28px 22px 20px;
-  }
-
-  .cardLongText .cardContent {
-    padding-top: 22px;
-  }
-
-  .cardWithPhoto .mainContent {
     padding: 18px;
+  }
+
+  .mainContent {
+    padding-right: 78px;
+    padding-bottom: 78px;
+  }
+
+  .cardWithPhoto .textPanel {
+    width: 100%;
+    padding: 18px;
+  }
+
+  .topMetaRight {
+    max-width: 48%;
+    font-size: 0.7rem;
   }
 
   .photoModes {
     grid-template-columns: 1fr;
   }
 
-  .signatureBar {
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 10px;
-    padding: 10px 11px;
+  .qrCorner {
+    right: 16px;
+    bottom: 16px;
+    padding: 7px 7px 5px;
   }
 
-  .qrInline {
-    gap: 6px;
-  }
-
-  .qrInline span {
-    display: none;
-  }
-
-  .inviteBadge {
-    gap: 10px;
-    padding-left: 14px;
+  .qrCorner span {
+    font-size: 0.58rem;
   }
 
   .actions {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -55,7 +55,7 @@
   margin-top: -10px;
   text-align: right;
   color: #8d8379;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
 }
 
 .photoButton,
@@ -106,17 +106,37 @@
   color: #514a44;
 }
 
+.qrNote {
+  margin: 2px 0 0;
+  padding-left: 12px;
+  border-left: 3px solid #efb08f;
+  color: #756b62;
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
 .card {
   position: relative;
   width: 100%;
   aspect-ratio: 4 / 5;
   overflow: hidden;
   border-radius: 28px;
-  background: linear-gradient(145deg, #fff4dc, #f7c8aa 55%, #df8c6a);
+  background:
+    radial-gradient(circle at 18% 15%, rgba(255, 255, 255, 0.72), transparent 28%),
+    linear-gradient(145deg, #fff4dc, #f7c8aa 55%, #df8c6a);
   box-shadow: 0 18px 50px rgba(87, 53, 36, 0.16);
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+}
+
+.card::after {
+  content: '';
+  position: absolute;
+  inset: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  border-radius: 20px;
+  pointer-events: none;
 }
 
 .cardWithPhoto {
@@ -133,8 +153,8 @@
   inset: 0;
   background: linear-gradient(
     180deg,
-    rgba(15, 13, 11, 0.24),
-    rgba(15, 13, 11, 0.72)
+    rgba(15, 13, 11, 0.22),
+    rgba(15, 13, 11, 0.76)
   );
 }
 
@@ -146,38 +166,98 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 24px;
+  gap: 20px;
+}
+
+.cardLongText .cardContent {
+  padding-top: 34px;
+  gap: 14px;
 }
 
 .mainContent {
   min-height: 0;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  justify-content: center;
+  gap: 22px;
+}
+
+.mainContentWithIllustration {
+  justify-content: flex-start;
 }
 
 .illustration {
   width: 100%;
-  max-height: 48%;
+  max-height: 42%;
   object-fit: contain;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.58);
+  box-shadow: 0 12px 28px rgba(54, 36, 26, 0.14);
+}
+
+.illustrationCompact {
+  max-height: 30%;
 }
 
 .quote {
+  position: relative;
+  min-height: 0;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  font-size: clamp(1.55rem, 4vw, 2.35rem);
   font-weight: 650;
-  line-height: 1.55;
   letter-spacing: 0.02em;
+  text-wrap: pretty;
+}
+
+.quote::before {
+  content: '“';
+  display: block;
+  margin-bottom: -0.16em;
+  color: rgba(154, 73, 38, 0.36);
+  font-family: Georgia, serif;
+  font-size: 1.75em;
+  font-weight: 400;
+  line-height: 0.7;
+}
+
+.cardWithPhoto .quote::before {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.quoteLarge {
+  font-size: clamp(1.85rem, 4.8vw, 2.75rem);
+  line-height: 1.48;
+}
+
+.quoteMedium {
+  font-size: clamp(1.48rem, 3.8vw, 2.08rem);
+  line-height: 1.52;
+}
+
+.quoteSmall {
+  font-size: clamp(1.16rem, 3vw, 1.55rem);
+  line-height: 1.52;
+}
+
+.quoteXSmall {
+  font-size: clamp(0.98rem, 2.45vw, 1.25rem);
+  line-height: 1.48;
+  letter-spacing: 0.01em;
 }
 
 .cardFooter {
+  flex: 0 0 auto;
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
   gap: 18px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(96, 64, 45, 0.2);
+}
+
+.cardWithPhoto .cardFooter {
+  border-top-color: rgba(255, 255, 255, 0.28);
 }
 
 .episodeInfo {
@@ -185,18 +265,29 @@
   flex-direction: column;
   gap: 5px;
   min-width: 0;
-  font-size: 0.83rem;
+  font-size: 0.8rem;
   line-height: 1.35;
+}
+
+.episodeInfo strong {
+  letter-spacing: 0.05em;
 }
 
 .episodeInfo span {
   opacity: 0.84;
 }
 
+.brandMark {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  opacity: 0.8;
+}
+
 .qrBlock {
-  flex: 0 0 92px;
+  flex: 0 0 94px;
   padding: 8px;
-  border-radius: 12px;
+  border-radius: 14px;
   background: #fff;
   color: #403a35;
   display: flex;
@@ -205,6 +296,7 @@
   gap: 5px;
   font-size: 0.58rem;
   text-align: center;
+  box-shadow: 0 8px 20px rgba(52, 34, 24, 0.14);
 }
 
 .actions {
@@ -234,6 +326,10 @@
 
   .cardContent {
     padding: 32px 26px 22px;
+  }
+
+  .cardLongText .cardContent {
+    padding-top: 26px;
   }
 
   .photoModes {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -145,27 +145,38 @@
 
 .photoLayer {
   position: absolute;
-  inset: -18px;
+  inset: 0;
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  filter: blur(8px) saturate(0.68) brightness(0.72);
-  transform: scale(1.05);
+  filter: brightness(0.84) saturate(0.94) contrast(0.98);
+  transform: scale(1.015);
 }
 
 .photoContain .photoLayer {
-  inset: 0;
   background-size: contain;
-  filter: saturate(0.72) brightness(0.66);
+  filter: brightness(0.9) saturate(0.96);
   transform: none;
 }
 
 .overlay {
   position: absolute;
   inset: 0;
-  background:
-    linear-gradient(180deg, rgba(28, 22, 18, 0.42), rgba(28, 22, 18, 0.74)),
-    rgba(117, 78, 55, 0.14);
+  background: linear-gradient(
+    180deg,
+    rgba(20, 16, 13, 0.08),
+    rgba(20, 16, 13, 0.22) 48%,
+    rgba(20, 16, 13, 0.48)
+  );
+}
+
+.photoContain .overlay {
+  background: linear-gradient(
+    180deg,
+    rgba(20, 16, 13, 0.03),
+    rgba(20, 16, 13, 0.12) 55%,
+    rgba(20, 16, 13, 0.34)
+  );
 }
 
 .cardContent {
@@ -191,6 +202,27 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+}
+
+.cardWithPhoto .mainContent {
+  margin: 4px -4px 0;
+  padding: 18px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 22px;
+  background: linear-gradient(
+    145deg,
+    rgba(24, 19, 16, 0.28),
+    rgba(24, 19, 16, 0.42)
+  );
+  box-shadow: 0 14px 34px rgba(20, 14, 10, 0.12);
+}
+
+.photoContain .mainContent {
+  background: linear-gradient(
+    145deg,
+    rgba(24, 19, 16, 0.34),
+    rgba(24, 19, 16, 0.48)
+  );
 }
 
 .quote {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -162,25 +162,26 @@
   position: relative;
   z-index: 1;
   height: 100%;
-  padding: 42px 38px 28px;
+  padding: 40px 38px 28px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 20px;
+  gap: 18px;
 }
 
 .cardLongText .cardContent {
-  padding-top: 34px;
-  gap: 14px;
+  padding-top: 30px;
+  gap: 12px;
 }
 
 .mainContent {
   min-height: 0;
-  flex: 1;
+  flex: 1 1 auto;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 22px;
+  gap: 18px;
 }
 
 .mainContentWithIllustration {
@@ -189,7 +190,9 @@
 
 .illustration {
   width: 100%;
-  max-height: 42%;
+  max-height: 38%;
+  min-height: 0;
+  flex: 0 1 auto;
   object-fit: contain;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.58);
@@ -197,15 +200,19 @@
 }
 
 .illustrationCompact {
-  max-height: 30%;
+  max-height: 22%;
 }
 
 .quote {
   position: relative;
   min-height: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  font-size: 42px;
   font-weight: 650;
+  line-height: 1.5;
   letter-spacing: 0.02em;
   text-wrap: pretty;
 }
@@ -216,34 +223,17 @@
   margin-bottom: -0.16em;
   color: rgba(154, 73, 38, 0.36);
   font-family: Georgia, serif;
-  font-size: 1.75em;
+  font-size: 1.55em;
   font-weight: 400;
   line-height: 0.7;
 }
 
+.cardLongText .quote::before {
+  display: none;
+}
+
 .cardWithPhoto .quote::before {
   color: rgba(255, 255, 255, 0.5);
-}
-
-.quoteLarge {
-  font-size: clamp(1.85rem, 4.8vw, 2.75rem);
-  line-height: 1.48;
-}
-
-.quoteMedium {
-  font-size: clamp(1.48rem, 3.8vw, 2.08rem);
-  line-height: 1.52;
-}
-
-.quoteSmall {
-  font-size: clamp(1.16rem, 3vw, 1.55rem);
-  line-height: 1.52;
-}
-
-.quoteXSmall {
-  font-size: clamp(0.98rem, 2.45vw, 1.25rem);
-  line-height: 1.48;
-  letter-spacing: 0.01em;
 }
 
 .cardFooter {
@@ -252,7 +242,7 @@
   align-items: flex-end;
   justify-content: space-between;
   gap: 18px;
-  padding-top: 14px;
+  padding-top: 12px;
   border-top: 1px solid rgba(96, 64, 45, 0.2);
 }
 
@@ -263,18 +253,22 @@
 .episodeInfo {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 4px;
   min-width: 0;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   line-height: 1.35;
 }
 
 .episodeInfo strong {
-  letter-spacing: 0.05em;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  letter-spacing: 0.02em;
 }
 
 .episodeInfo span {
-  opacity: 0.84;
+  opacity: 0.78;
 }
 
 .brandMark {
@@ -329,7 +323,7 @@
   }
 
   .cardLongText .cardContent {
-    padding-top: 26px;
+    padding-top: 24px;
   }
 
   .photoModes {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -46,7 +46,8 @@
   background: white;
 }
 
-.textarea:focus {
+.textarea:focus,
+.authorField input:focus {
   outline: 3px solid rgba(255, 127, 80, 0.2);
   border-color: #ff7f50;
 }
@@ -56,6 +57,33 @@
   text-align: right;
   color: #8d8379;
   font-size: 0.82rem;
+}
+
+.authorField {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px 12px;
+  color: #514a44;
+  font-size: 0.92rem;
+}
+
+.authorField > span {
+  font-weight: 700;
+}
+
+.authorField input {
+  min-width: 0;
+  border: 1px solid #ded4c9;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font: inherit;
+  background: #fff;
+}
+
+.authorField small {
+  grid-column: 2;
+  color: #8d8379;
 }
 
 .photoButton,
@@ -189,6 +217,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: 14px;
 }
 
 .cardWithPhoto .mainContent {
@@ -235,6 +264,24 @@
 
 .cardWithPhoto .quote::before {
   color: rgba(255, 255, 255, 0.48);
+}
+
+.byline {
+  flex: 0 0 auto;
+  align-self: flex-end;
+  max-width: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.88rem;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  opacity: 0.78;
+}
+
+.cardWithPhoto .byline {
+  opacity: 0.88;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.28);
 }
 
 .signatureBar {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -205,6 +205,8 @@
 .cardContent {
   position: relative;
   z-index: 2;
+  box-sizing: border-box;
+  width: 100%;
   height: 100%;
   padding: 22px;
   display: flex;
@@ -250,10 +252,9 @@
 }
 
 .mainContent {
-  position: relative;
   min-height: 0;
   flex: 1 1 auto;
-  overflow: hidden;
+  overflow: visible;
   display: flex;
   align-items: center;
   padding: 18px 0 0;
@@ -286,9 +287,10 @@
 
 .qrFloat {
   position: absolute;
-  right: -14px;
-  bottom: -14px;
+  right: 16px;
+  bottom: 16px;
   z-index: 4;
+  box-sizing: border-box;
   width: 70px;
   margin: 0;
   padding: 6px 6px 5px;
@@ -421,8 +423,8 @@
   }
 
   .qrFloat {
-    right: -10px;
-    bottom: -10px;
+    right: 14px;
+    bottom: 14px;
     width: 64px;
     padding: 5px 5px 4px;
   }

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -69,6 +69,30 @@
   padding: 0;
 }
 
+.photoModes {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.photoModes button {
+  border: 1px solid #ded4c9;
+  border-radius: 999px;
+  padding: 9px 10px;
+  background: #fff;
+  color: #5d554e;
+  font: inherit;
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+
+.photoModes .activeMode {
+  border-color: #d86f42;
+  background: #fff1e8;
+  color: #a94e2b;
+  font-weight: 700;
+}
+
 .settings {
   display: flex;
   flex-direction: column;
@@ -92,16 +116,26 @@
   box-shadow: 0 18px 50px rgba(87, 53, 36, 0.16);
   background-size: cover;
   background-position: center;
+  background-repeat: no-repeat;
 }
 
 .cardWithPhoto {
   color: #fff;
 }
 
+.photoContain {
+  background-size: contain;
+  background-color: #2a2521;
+}
+
 .overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(15, 13, 11, 0.28), rgba(15, 13, 11, 0.68));
+  background: linear-gradient(
+    180deg,
+    rgba(15, 13, 11, 0.24),
+    rgba(15, 13, 11, 0.72)
+  );
 }
 
 .cardContent {
@@ -112,6 +146,22 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 24px;
+}
+
+.mainContent {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.illustration {
+  width: 100%;
+  max-height: 48%;
+  object-fit: contain;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.55);
 }
 
 .quote {
@@ -184,6 +234,10 @@
 
   .cardContent {
     padding: 32px 26px 22px;
+  }
+
+  .photoModes {
+    grid-template-columns: 1fr;
   }
 
   .actions {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -161,25 +161,38 @@
   background: #1f1b18;
 }
 
-.photoLayer {
+.photoLayer,
+.photoForeground {
   position: absolute;
   inset: 0;
-  background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+}
+
+.photoLayer {
+  z-index: 0;
+  background-size: cover;
   filter: brightness(0.96) saturate(0.98);
   transform: scale(1.01);
 }
 
 .photoContain .photoLayer {
+  inset: -18px;
+  background-size: cover;
+  filter: blur(18px) brightness(0.72) saturate(0.9);
+  transform: scale(1.1);
+}
+
+.photoForeground {
+  z-index: 1;
   background-size: contain;
-  transform: none;
-  background-color: #211d1a;
+  filter: brightness(0.96) saturate(0.98);
 }
 
 .overlay {
   position: absolute;
   inset: 0;
+  z-index: 1;
   background: linear-gradient(
     180deg,
     rgba(8, 7, 6, 0.03) 0%,
@@ -264,7 +277,11 @@
 }
 
 .cardLongText .textPanel {
-  padding-bottom: 18px;
+  padding-bottom: 86px;
+}
+
+.cardWithPhoto.cardLongText .textPanel {
+  padding-bottom: 94px;
 }
 
 .qrFloat {
@@ -279,12 +296,6 @@
   color: #4a372d;
   text-align: center;
   box-shadow: 0 10px 24px rgba(48, 31, 22, 0.14);
-}
-
-.cardLongText .qrFloat {
-  position: static;
-  float: right;
-  margin: 0 0 10px 16px;
 }
 
 .qrFloat svg {
@@ -338,7 +349,6 @@
 }
 
 .byline {
-  clear: both;
   margin-top: 16px;
   max-width: 70%;
   overflow: hidden;
@@ -392,6 +402,14 @@
     padding: 18px;
   }
 
+  .cardLongText .textPanel {
+    padding-bottom: 80px;
+  }
+
+  .cardWithPhoto.cardLongText .textPanel {
+    padding-bottom: 88px;
+  }
+
   .expressionCue {
     max-width: 52%;
     font-size: 0.68rem;
@@ -404,10 +422,6 @@
   .qrFloat {
     width: 64px;
     padding: 5px 5px 4px;
-  }
-
-  .cardLongText .qrFloat {
-    margin-left: 12px;
   }
 
   .qrFloat span {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -71,7 +71,7 @@
 
 .photoModes {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 8px;
 }
 
@@ -121,19 +121,18 @@
   aspect-ratio: 4 / 5;
   overflow: hidden;
   border-radius: 28px;
+  color: #4c3529;
   background:
     radial-gradient(circle at 18% 15%, rgba(255, 255, 255, 0.72), transparent 28%),
     linear-gradient(145deg, #fff4dc, #f7c8aa 55%, #df8c6a);
   box-shadow: 0 18px 50px rgba(87, 53, 36, 0.16);
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
 }
 
 .card::after {
   content: '';
   position: absolute;
   inset: 14px;
+  z-index: 3;
   border: 1px solid rgba(255, 255, 255, 0.34);
   border-radius: 20px;
   pointer-events: none;
@@ -141,26 +140,37 @@
 
 .cardWithPhoto {
   color: #fff;
+  background: #463a34;
 }
 
-.photoContain {
+.photoLayer {
+  position: absolute;
+  inset: -18px;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  filter: blur(8px) saturate(0.68) brightness(0.72);
+  transform: scale(1.05);
+}
+
+.photoContain .photoLayer {
+  inset: 0;
   background-size: contain;
-  background-color: #2a2521;
+  filter: saturate(0.72) brightness(0.66);
+  transform: none;
 }
 
 .overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    180deg,
-    rgba(15, 13, 11, 0.22),
-    rgba(15, 13, 11, 0.76)
-  );
+  background:
+    linear-gradient(180deg, rgba(28, 22, 18, 0.42), rgba(28, 22, 18, 0.74)),
+    rgba(117, 78, 55, 0.14);
 }
 
 .cardContent {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   height: 100%;
   padding: 40px 38px 28px;
   display: flex;
@@ -181,26 +191,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 18px;
-}
-
-.mainContentWithIllustration {
-  justify-content: flex-start;
-}
-
-.illustration {
-  width: 100%;
-  max-height: 38%;
-  min-height: 0;
-  flex: 0 1 auto;
-  object-fit: contain;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.58);
-  box-shadow: 0 12px 28px rgba(54, 36, 26, 0.14);
-}
-
-.illustrationCompact {
-  max-height: 22%;
 }
 
 .quote {
@@ -215,6 +205,7 @@
   line-height: 1.5;
   letter-spacing: 0.02em;
   text-wrap: pretty;
+  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.08);
 }
 
 .quote::before {
@@ -238,10 +229,11 @@
 
 .cardFooter {
   flex: 0 0 auto;
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 18px;
+  min-height: 106px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 94px;
+  align-items: end;
+  gap: 20px;
   padding-top: 12px;
   border-top: 1px solid rgba(96, 64, 45, 0.2);
 }
@@ -250,13 +242,15 @@
   border-top-color: rgba(255, 255, 255, 0.28);
 }
 
-.episodeInfo {
+.episodeInfo,
+.brandBlock {
+  align-self: center;
+  min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  min-width: 0;
+  gap: 5px;
   font-size: 0.78rem;
-  line-height: 1.35;
+  line-height: 1.42;
 }
 
 .episodeInfo strong {
@@ -267,19 +261,18 @@
   letter-spacing: 0.02em;
 }
 
-.episodeInfo span {
+.episodeInfo span,
+.brandBlock span {
   opacity: 0.78;
 }
 
-.brandMark {
-  font-size: 0.78rem;
-  font-weight: 700;
+.brandBlock strong {
+  font-size: 0.9rem;
   letter-spacing: 0.12em;
-  opacity: 0.8;
 }
 
 .qrBlock {
-  flex: 0 0 94px;
+  width: 94px;
   padding: 8px;
   border-radius: 14px;
   background: #fff;
@@ -328,6 +321,15 @@
 
   .photoModes {
     grid-template-columns: 1fr;
+  }
+
+  .cardFooter {
+    grid-template-columns: minmax(0, 1fr) 90px;
+    gap: 14px;
+  }
+
+  .qrBlock {
+    width: 90px;
   }
 
   .actions {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -237,6 +237,7 @@
 }
 
 .mainContent {
+  position: relative;
   min-height: 0;
   flex: 1 1 auto;
   overflow: hidden;
@@ -267,15 +268,23 @@
 }
 
 .qrFloat {
-  float: right;
+  position: absolute;
+  right: 0;
+  bottom: 0;
   width: 70px;
-  margin: 0 0 10px 16px;
+  margin: 0;
   padding: 6px 6px 5px;
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.95);
   color: #4a372d;
   text-align: center;
   box-shadow: 0 10px 24px rgba(48, 31, 22, 0.14);
+}
+
+.cardLongText .qrFloat {
+  position: static;
+  float: right;
+  margin: 0 0 10px 16px;
 }
 
 .qrFloat svg {
@@ -394,8 +403,11 @@
 
   .qrFloat {
     width: 64px;
-    margin-left: 12px;
     padding: 5px 5px 4px;
+  }
+
+  .cardLongText .qrFloat {
+    margin-left: 12px;
   }
 
   .qrFloat span {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -221,20 +221,18 @@
   background: rgba(255, 255, 255, 0.82);
 }
 
-.topMetaRight {
-  max-width: 55%;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 3px;
+.expressionCue {
+  max-width: 58%;
+  padding-top: 4px;
   text-align: right;
   font-size: 0.74rem;
   line-height: 1.35;
-  color: rgba(82, 62, 51, 0.88);
+  letter-spacing: 0.08em;
+  color: rgba(82, 62, 51, 0.72);
 }
 
-.cardWithPhoto .topMetaRight {
-  color: rgba(255, 255, 255, 0.9);
+.cardWithPhoto .expressionCue {
+  color: rgba(255, 255, 255, 0.86);
   text-shadow: 0 1px 10px rgba(0, 0, 0, 0.28);
 }
 
@@ -244,7 +242,7 @@
   overflow: hidden;
   display: flex;
   align-items: center;
-  padding: 18px 86px 86px 0;
+  padding: 18px 0 0;
 }
 
 .textPanel {
@@ -252,7 +250,7 @@
 }
 
 .cardWithPhoto .textPanel {
-  width: min(100%, 88%);
+  width: 100%;
   padding: 20px 22px;
   border-radius: 24px;
   background: linear-gradient(
@@ -268,10 +266,36 @@
   padding-bottom: 18px;
 }
 
+.qrFloat {
+  float: right;
+  width: 70px;
+  margin: 0 0 10px 16px;
+  padding: 6px 6px 5px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #4a372d;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(48, 31, 22, 0.14);
+}
+
+.qrFloat svg {
+  display: block;
+  margin: 0 auto;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.qrFloat span {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.58rem;
+  line-height: 1.15;
+}
+
 .quote {
   position: relative;
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   font-size: 42px;
@@ -305,6 +329,7 @@
 }
 
 .byline {
+  clear: both;
   margin-top: 16px;
   max-width: 70%;
   overflow: hidden;
@@ -319,31 +344,6 @@
 .cardWithPhoto .byline {
   color: rgba(255, 255, 255, 0.92);
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.26);
-}
-
-.qrCorner {
-  position: absolute;
-  right: 20px;
-  bottom: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 5px;
-  padding: 8px 8px 6px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.94);
-  color: #4a372d;
-  box-shadow: 0 12px 28px rgba(48, 31, 22, 0.16);
-}
-
-.qrCorner svg {
-  border-radius: 10px;
-  background: #fff;
-}
-
-.qrCorner span {
-  font-size: 0.64rem;
-  line-height: 1.2;
 }
 
 .actions {
@@ -376,32 +376,30 @@
   }
 
   .mainContent {
-    padding-right: 78px;
-    padding-bottom: 78px;
+    padding-top: 14px;
   }
 
   .cardWithPhoto .textPanel {
-    width: 100%;
     padding: 18px;
   }
 
-  .topMetaRight {
-    max-width: 48%;
-    font-size: 0.7rem;
+  .expressionCue {
+    max-width: 52%;
+    font-size: 0.68rem;
   }
 
   .photoModes {
     grid-template-columns: 1fr;
   }
 
-  .qrCorner {
-    right: 16px;
-    bottom: 16px;
-    padding: 7px 7px 5px;
+  .qrFloat {
+    width: 64px;
+    margin-left: 12px;
+    padding: 5px 5px 4px;
   }
 
-  .qrCorner span {
-    font-size: 0.58rem;
+  .qrFloat span {
+    font-size: 0.54rem;
   }
 
   .actions {

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -318,6 +318,7 @@ const EpisodeCardCreate: React.FC = () => {
             </>
           )}
           {photo && <div className={styles.overlay} />}
+
           <div className={styles.cardContent}>
             <div className={styles.topMeta}>
               <div className={styles.brandChip}>
@@ -330,16 +331,17 @@ const EpisodeCardCreate: React.FC = () => {
 
             <div ref={mainContentRef} className={styles.mainContent}>
               <div className={styles.textPanel}>
-                <div className={styles.qrFloat}>
-                  <QRCodeSVG value={shareUrl} size={54} bgColor="#ffffff" />
-                  <span>扫码回应</span>
-                </div>
                 <div ref={quoteRef} className={styles.quote}>
                   {displayText}
                 </div>
                 <div className={styles.byline}>— {displayAuthor}</div>
               </div>
             </div>
+          </div>
+
+          <div className={styles.qrFloat}>
+            <QRCodeSVG value={shareUrl} size={54} bgColor="#ffffff" />
+            <span>扫码回应</span>
           </div>
         </div>
 

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -85,8 +85,6 @@ const EpisodeCardCreate: React.FC = () => {
     const quote = quoteRef.current;
     if (!container || !quote) return;
 
-    let animationFrame = 0;
-
     const fitText = () => {
       const initialSize =
         weightedLength > 180
@@ -111,16 +109,13 @@ const EpisodeCardCreate: React.FC = () => {
       }
     };
 
-    animationFrame = window.requestAnimationFrame(fitText);
-    const observer = new ResizeObserver(() => {
-      window.cancelAnimationFrame(animationFrame);
-      animationFrame = window.requestAnimationFrame(fitText);
-    });
-    observer.observe(container);
+    const animationFrame = window.requestAnimationFrame(fitText);
+    const image = container.querySelector('img');
+    image?.addEventListener('load', fitText);
 
     return () => {
       window.cancelAnimationFrame(animationFrame);
-      observer.disconnect();
+      image?.removeEventListener('load', fitText);
     };
   }, [displayText, weightedLength, photo, photoMode, showEpisodeInfo]);
 

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -17,7 +17,7 @@ import { getUserName } from '@/utils';
 import { saveImageDataUrl } from '@/utils/share';
 import styles from './episodeCardCreate.module.css';
 
-const MAX_TEXT_LENGTH = 240;
+const MAX_TEXT_LENGTH = 500;
 const MAX_AUTHOR_LENGTH = 24;
 const DEFAULT_INSPIRE_PLANET_MEETUP_ID = 39;
 
@@ -82,7 +82,7 @@ const EpisodeCardCreate: React.FC = () => {
   const weightedLength =
     Array.from(displayText).length +
     Math.max(0, displayText.split('\n').length - 1) * 12;
-  const hasLongText = weightedLength > 125;
+  const hasLongText = weightedLength > 180;
 
   useLayoutEffect(() => {
     const container = mainContentRef.current;
@@ -91,21 +91,26 @@ const EpisodeCardCreate: React.FC = () => {
 
     const fitText = () => {
       const initialSize =
-        weightedLength > 180
-          ? 20
-          : weightedLength > 125
-            ? 24
-            : weightedLength > 72
-              ? 31
-              : 42;
+        weightedLength > 420
+          ? 13
+          : weightedLength > 300
+            ? 15
+            : weightedLength > 180
+              ? 18
+              : weightedLength > 110
+                ? 24
+                : weightedLength > 72
+                  ? 31
+                  : 42;
       let fontSize = initialSize;
 
       quote.style.fontSize = `${fontSize}px`;
-      quote.style.lineHeight = weightedLength > 180 ? '1.4' : '1.5';
+      quote.style.lineHeight =
+        weightedLength > 300 ? '1.32' : weightedLength > 180 ? '1.4' : '1.5';
 
       while (
         container.scrollHeight > container.clientHeight &&
-        fontSize > 14
+        fontSize > 10
       ) {
         fontSize -= 1;
         quote.style.fontSize = `${fontSize}px`;
@@ -210,15 +215,6 @@ const EpisodeCardCreate: React.FC = () => {
 
   if (!episode) return null;
 
-  const cardTitle = episode.theme || episode.meetup.title;
-  const dateLabel = episode.date
-    ? new Date(`${episode.date}T00:00:00`).toLocaleDateString('zh-CN', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
-    : '';
-
   return (
     <main className={styles.page}>
       <section className={styles.editor}>
@@ -292,10 +288,10 @@ const EpisodeCardCreate: React.FC = () => {
               checked={showEpisodeInfo}
               onChange={(_, value) => setShowEpisodeInfo(value)}
             />
-            顶部显示期次与主题
+            顶部显示期次
           </label>
           <p className={styles.qrNote}>
-            二维码会固定保留在卡片角落，让看到卡片的人也能继续写下自己的启发。
+            二维码会融入正文排版，让看到卡片的人也能继续写下自己的启发。
           </p>
         </div>
       </section>
@@ -317,28 +313,24 @@ const EpisodeCardCreate: React.FC = () => {
           <div className={styles.cardContent}>
             <div className={styles.topMeta}>
               <div className={styles.brandChip}>
-                {showEpisodeInfo ? `启发星球 EP${episode.episode_number}` : '启发星球'}
+                {showEpisodeInfo
+                  ? `启发星球 EP${episode.episode_number}`
+                  : '启发星球'}
               </div>
-              {showEpisodeInfo && (
-                <div className={styles.topMetaRight}>
-                  <span>{cardTitle}</span>
-                  {dateLabel && <span>{dateLabel}</span>}
-                </div>
-              )}
+              <div className={styles.expressionCue}>真实 · 自由 · 不必完整</div>
             </div>
 
             <div ref={mainContentRef} className={styles.mainContent}>
               <div className={styles.textPanel}>
+                <div className={styles.qrFloat}>
+                  <QRCodeSVG value={shareUrl} size={54} bgColor="#ffffff" />
+                  <span>扫码回应</span>
+                </div>
                 <div ref={quoteRef} className={styles.quote}>
                   {displayText}
                 </div>
                 <div className={styles.byline}>— {displayAuthor}</div>
               </div>
-            </div>
-
-            <div className={styles.qrCorner}>
-              <QRCodeSVG value={shareUrl} size={56} bgColor="#ffffff" />
-              <span>扫码回应</span>
             </div>
           </div>
         </div>

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -292,10 +292,10 @@ const EpisodeCardCreate: React.FC = () => {
               checked={showEpisodeInfo}
               onChange={(_, value) => setShowEpisodeInfo(value)}
             />
-            显示期次与主题
+            顶部显示期次与主题
           </label>
           <p className={styles.qrNote}>
-            邀请二维码会固定保留，让看到卡片的人也能写下自己的启发。
+            二维码会固定保留在卡片角落，让看到卡片的人也能继续写下自己的启发。
           </p>
         </div>
       </section>
@@ -315,34 +315,31 @@ const EpisodeCardCreate: React.FC = () => {
           )}
           {photo && <div className={styles.overlay} />}
           <div className={styles.cardContent}>
-            <div ref={mainContentRef} className={styles.mainContent}>
-              <div ref={quoteRef} className={styles.quote}>
-                {displayText}
+            <div className={styles.topMeta}>
+              <div className={styles.brandChip}>
+                {showEpisodeInfo ? `启发星球 EP${episode.episode_number}` : '启发星球'}
               </div>
-              <div className={styles.byline}>— {displayAuthor}</div>
-            </div>
-
-            {showEpisodeInfo ? (
-              <div className={styles.signatureBar}>
-                <div className={styles.episodeInfo}>
-                  <span className={styles.episodeLabel}>EP{episode.episode_number}</span>
-                  <strong>{cardTitle}</strong>
+              {showEpisodeInfo && (
+                <div className={styles.topMetaRight}>
+                  <span>{cardTitle}</span>
                   {dateLabel && <span>{dateLabel}</span>}
                 </div>
-                <div className={styles.qrInline}>
-                  <QRCodeSVG value={shareUrl} size={58} bgColor="#ffffff" />
-                  <span>扫码写下你的启发</span>
+              )}
+            </div>
+
+            <div ref={mainContentRef} className={styles.mainContent}>
+              <div className={styles.textPanel}>
+                <div ref={quoteRef} className={styles.quote}>
+                  {displayText}
                 </div>
+                <div className={styles.byline}>— {displayAuthor}</div>
               </div>
-            ) : (
-              <div className={styles.inviteBadge}>
-                <div className={styles.inviteCopy}>
-                  <strong>启发星球</strong>
-                  <span>也写下你的这一刻</span>
-                </div>
-                <QRCodeSVG value={shareUrl} size={58} bgColor="#ffffff" />
-              </div>
-            )}
+            </div>
+
+            <div className={styles.qrCorner}>
+              <QRCodeSVG value={shareUrl} size={56} bgColor="#ffffff" />
+              <span>扫码回应</span>
+            </div>
           </div>
         </div>
 

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -10,14 +10,23 @@ import { saveImageDataUrl } from '@/utils/share';
 import styles from './episodeCardCreate.module.css';
 
 const MAX_TEXT_LENGTH = 180;
+const DEFAULT_INSPIRE_PLANET_MEETUP_ID = 39;
+
+type PhotoMode = 'cover' | 'contain' | 'illustration';
 
 const EpisodeCardCreate: React.FC = () => {
   const [searchParams] = useSearchParams();
-  const episodeId = Number(searchParams.get('episodeId'));
+  const episodeNumber = Number(
+    searchParams.get('episode') || searchParams.get('episodeId')
+  );
+  const meetupId = Number(
+    searchParams.get('meetupId') || DEFAULT_INSPIRE_PLANET_MEETUP_ID
+  );
   const previewRef = useRef<HTMLDivElement>(null);
   const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
   const [text, setText] = useState('');
   const [photo, setPhoto] = useState<string | null>(null);
+  const [photoMode, setPhotoMode] = useState<PhotoMode>('cover');
   const [showEpisodeInfo, setShowEpisodeInfo] = useState(true);
   const [showQrCode, setShowQrCode] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
@@ -26,14 +35,17 @@ const EpisodeCardCreate: React.FC = () => {
 
   useEffect(() => {
     const loadEpisode = async () => {
-      if (!episodeId) {
-        setError('缺少有效的期次信息');
+      if (!episodeNumber || !meetupId) {
+        setError('缺少有效的活动或期数信息');
         setIsLoading(false);
         return;
       }
 
       try {
-        const response = await episodesApi.getById(episodeId);
+        const response = await episodesApi.getByMeetupEpisode(
+          meetupId,
+          episodeNumber
+        );
         if (!response.success || !response.data?.episode) {
           throw new Error(response.error || '无法读取本期活动');
         }
@@ -46,11 +58,12 @@ const EpisodeCardCreate: React.FC = () => {
     };
 
     loadEpisode();
-  }, [episodeId]);
+  }, [episodeNumber, meetupId]);
 
   const shareUrl = useMemo(
-    () => `${window.location.origin}/create-card?episodeId=${episodeId}`,
-    [episodeId]
+    () =>
+      `${window.location.origin}/create-card?meetupId=${meetupId}&episode=${episodeNumber}`,
+    [episodeNumber, meetupId]
   );
 
   const handlePhoto = (event: ChangeEvent<HTMLInputElement>) => {
@@ -115,7 +128,7 @@ const EpisodeCardCreate: React.FC = () => {
         await navigator.share({
           files: [file],
           title: `启发星球 EP${episode?.episode_number}`,
-          text: '这是我从这一期带走的一句话。',
+          text: '这是我从这次相遇里带走的一句话。',
         });
       } else {
         saveImageDataUrl(canvas.toDataURL('image/png'), file.name);
@@ -131,27 +144,37 @@ const EpisodeCardCreate: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className={styles.state}><CircularProgress /></div>
+      <div className={styles.state}>
+        <CircularProgress />
+      </div>
     );
   }
 
   if (error && !episode) {
-    return <div className={styles.state}><Alert severity="error">{error}</Alert></div>;
+    return (
+      <div className={styles.state}>
+        <Alert severity="error">{error}</Alert>
+      </div>
+    );
   }
 
   if (!episode) return null;
 
   const cardTitle = episode.theme || episode.meetup.title;
-  const dateLabel = new Date(`${episode.date}T00:00:00`).toLocaleDateString(
-    'zh-CN',
-    { year: 'numeric', month: 'long', day: 'numeric' }
-  );
+  const dateLabel = episode.date
+    ? new Date(`${episode.date}T00:00:00`).toLocaleDateString('zh-CN', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : '';
+  const usesBackgroundPhoto = photo && photoMode !== 'illustration';
 
   return (
     <main className={styles.page}>
       <section className={styles.editor}>
         <p className={styles.eyebrow}>启发星球 EP{episode.episode_number}</p>
-        <h1>今晚，你想带走什么？</h1>
+        <h1>这次相遇，你想带走什么？</h1>
         <p className={styles.description}>
           写下一句话、一段感受，或者一个接下来想做的行动。
         </p>
@@ -166,39 +189,99 @@ const EpisodeCardCreate: React.FC = () => {
           className={styles.textarea}
           autoFocus
         />
-        <div className={styles.counter}>{text.length}/{MAX_TEXT_LENGTH}</div>
+        <div className={styles.counter}>
+          {text.length}/{MAX_TEXT_LENGTH}
+        </div>
 
         <label className={styles.photoButton}>
           ＋ 添加一张照片（可选）
           <input type="file" accept="image/*" onChange={handlePhoto} hidden />
         </label>
         {photo && (
-          <button className={styles.removePhoto} onClick={() => setPhoto(null)}>
-            移除照片
-          </button>
+          <>
+            <div className={styles.photoModes} aria-label="照片展示方式">
+              <button
+                type="button"
+                className={photoMode === 'cover' ? styles.activeMode : ''}
+                onClick={() => setPhotoMode('cover')}
+              >
+                铺满裁切
+              </button>
+              <button
+                type="button"
+                className={photoMode === 'contain' ? styles.activeMode : ''}
+                onClick={() => setPhotoMode('contain')}
+              >
+                完整显示
+              </button>
+              <button
+                type="button"
+                className={photoMode === 'illustration' ? styles.activeMode : ''}
+                onClick={() => setPhotoMode('illustration')}
+              >
+                作为插图
+              </button>
+            </div>
+            <button
+              type="button"
+              className={styles.removePhoto}
+              onClick={() => setPhoto(null)}
+            >
+              移除照片
+            </button>
+          </>
         )}
 
         <div className={styles.settings}>
-          <label><Switch checked={showEpisodeInfo} onChange={(_, value) => setShowEpisodeInfo(value)} />显示本期信息</label>
-          <label><Switch checked={showQrCode} onChange={(_, value) => setShowQrCode(value)} />显示邀请二维码</label>
+          <label>
+            <Switch
+              checked={showEpisodeInfo}
+              onChange={(_, value) => setShowEpisodeInfo(value)}
+            />
+            显示本期信息
+          </label>
+          <label>
+            <Switch
+              checked={showQrCode}
+              onChange={(_, value) => setShowQrCode(value)}
+            />
+            显示邀请二维码
+          </label>
         </div>
       </section>
 
       <section className={styles.previewSection}>
         <div
           ref={previewRef}
-          className={`${styles.card} ${photo ? styles.cardWithPhoto : ''}`}
-          style={photo ? { backgroundImage: `url(${photo})` } : undefined}
+          className={`${styles.card} ${
+            usesBackgroundPhoto ? styles.cardWithPhoto : ''
+          } ${photoMode === 'contain' ? styles.photoContain : ''}`}
+          style={
+            usesBackgroundPhoto
+              ? { backgroundImage: `url(${photo})` }
+              : undefined
+          }
         >
-          {photo && <div className={styles.overlay} />}
+          {usesBackgroundPhoto && <div className={styles.overlay} />}
           <div className={styles.cardContent}>
-            <div className={styles.quote}>{text.trim() || '你想从今晚带走什么？'}</div>
+            <div className={styles.mainContent}>
+              {photo && photoMode === 'illustration' && (
+                <img
+                  src={photo}
+                  alt="用户选择的插图"
+                  className={styles.illustration}
+                />
+              )}
+              <div className={styles.quote}>
+                {text.trim() || '你想从这次相遇带走什么？'}
+              </div>
+            </div>
             <div className={styles.cardFooter}>
               {showEpisodeInfo && (
                 <div className={styles.episodeInfo}>
                   <strong>启发星球 EP{episode.episode_number}</strong>
                   <span>{cardTitle}</span>
-                  <span>{dateLabel}</span>
+                  {dateLabel && <span>{dateLabel}</span>}
                 </div>
               )}
               {showQrCode && (
@@ -212,10 +295,20 @@ const EpisodeCardCreate: React.FC = () => {
         </div>
 
         <div className={styles.actions}>
-          <Button variant="contained" size="large" disabled={!text.trim() || isExporting} onClick={handleShare}>
+          <Button
+            variant="contained"
+            size="large"
+            disabled={!text.trim() || isExporting}
+            onClick={handleShare}
+          >
             {isExporting ? '正在生成…' : '生成并分享'}
           </Button>
-          <Button variant="outlined" size="large" disabled={!text.trim() || isExporting} onClick={handleDownload}>
+          <Button
+            variant="outlined"
+            size="large"
+            disabled={!text.trim() || isExporting}
+            onClick={handleDownload}
+          >
             保存图片
           </Button>
         </div>

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -9,7 +9,7 @@ import { EpisodeCardContext } from '@/netlify/functions/episodes';
 import { saveImageDataUrl } from '@/utils/share';
 import styles from './episodeCardCreate.module.css';
 
-const MAX_TEXT_LENGTH = 180;
+const MAX_TEXT_LENGTH = 240;
 const DEFAULT_INSPIRE_PLANET_MEETUP_ID = 39;
 
 type PhotoMode = 'cover' | 'contain' | 'illustration';
@@ -28,7 +28,6 @@ const EpisodeCardCreate: React.FC = () => {
   const [photo, setPhoto] = useState<string | null>(null);
   const [photoMode, setPhotoMode] = useState<PhotoMode>('cover');
   const [showEpisodeInfo, setShowEpisodeInfo] = useState(true);
-  const [showQrCode, setShowQrCode] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -169,6 +168,19 @@ const EpisodeCardCreate: React.FC = () => {
       })
     : '';
   const usesBackgroundPhoto = photo && photoMode !== 'illustration';
+  const displayText = text.trim() || '你想从这次相遇带走什么？';
+  const weightedLength =
+    Array.from(displayText).length +
+    Math.max(0, displayText.split('\n').length - 1) * 12;
+  const quoteSizeClass =
+    weightedLength > 180
+      ? styles.quoteXSmall
+      : weightedLength > 125
+        ? styles.quoteSmall
+        : weightedLength > 72
+          ? styles.quoteMedium
+          : styles.quoteLarge;
+  const hasLongText = weightedLength > 125;
 
   return (
     <main className={styles.page}>
@@ -190,7 +202,7 @@ const EpisodeCardCreate: React.FC = () => {
           autoFocus
         />
         <div className={styles.counter}>
-          {text.length}/{MAX_TEXT_LENGTH}
+          {text.length}/{MAX_TEXT_LENGTH} · 卡片会自动调整字号
         </div>
 
         <label className={styles.photoButton}>
@@ -240,13 +252,9 @@ const EpisodeCardCreate: React.FC = () => {
             />
             显示本期信息
           </label>
-          <label>
-            <Switch
-              checked={showQrCode}
-              onChange={(_, value) => setShowQrCode(value)}
-            />
-            显示邀请二维码
-          </label>
+          <p className={styles.qrNote}>
+            邀请二维码会固定保留，让看到卡片的人也能写下自己的启发。
+          </p>
         </div>
       </section>
 
@@ -255,7 +263,9 @@ const EpisodeCardCreate: React.FC = () => {
           ref={previewRef}
           className={`${styles.card} ${
             usesBackgroundPhoto ? styles.cardWithPhoto : ''
-          } ${photoMode === 'contain' ? styles.photoContain : ''}`}
+          } ${photoMode === 'contain' ? styles.photoContain : ''} ${
+            hasLongText ? styles.cardLongText : ''
+          }`}
           style={
             usesBackgroundPhoto
               ? { backgroundImage: `url(${photo})` }
@@ -264,32 +274,40 @@ const EpisodeCardCreate: React.FC = () => {
         >
           {usesBackgroundPhoto && <div className={styles.overlay} />}
           <div className={styles.cardContent}>
-            <div className={styles.mainContent}>
+            <div
+              className={`${styles.mainContent} ${
+                photo && photoMode === 'illustration'
+                  ? styles.mainContentWithIllustration
+                  : ''
+              }`}
+            >
               {photo && photoMode === 'illustration' && (
                 <img
                   src={photo}
                   alt="用户选择的插图"
-                  className={styles.illustration}
+                  className={`${styles.illustration} ${
+                    hasLongText ? styles.illustrationCompact : ''
+                  }`}
                 />
               )}
-              <div className={styles.quote}>
-                {text.trim() || '你想从这次相遇带走什么？'}
+              <div className={`${styles.quote} ${quoteSizeClass}`}>
+                {displayText}
               </div>
             </div>
             <div className={styles.cardFooter}>
-              {showEpisodeInfo && (
+              {showEpisodeInfo ? (
                 <div className={styles.episodeInfo}>
                   <strong>启发星球 EP{episode.episode_number}</strong>
                   <span>{cardTitle}</span>
                   {dateLabel && <span>{dateLabel}</span>}
                 </div>
+              ) : (
+                <div className={styles.brandMark}>启发星球</div>
               )}
-              {showQrCode && (
-                <div className={styles.qrBlock}>
-                  <QRCodeSVG value={shareUrl} size={74} bgColor="#ffffff" />
-                  <span>扫码写下你的启发</span>
-                </div>
-              )}
+              <div className={styles.qrBlock}>
+                <QRCodeSVG value={shareUrl} size={74} bgColor="#ffffff" />
+                <span>扫码写下你的启发</span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -1,4 +1,11 @@
-import React, { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  ChangeEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Alert, Button, CircularProgress, Switch } from '@mui/material';
 import html2canvas from 'html2canvas';
 import { QRCodeSVG } from 'qrcode.react';
@@ -23,6 +30,8 @@ const EpisodeCardCreate: React.FC = () => {
     searchParams.get('meetupId') || DEFAULT_INSPIRE_PLANET_MEETUP_ID
   );
   const previewRef = useRef<HTMLDivElement>(null);
+  const mainContentRef = useRef<HTMLDivElement>(null);
+  const quoteRef = useRef<HTMLDivElement>(null);
   const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
   const [text, setText] = useState('');
   const [photo, setPhoto] = useState<string | null>(null);
@@ -64,6 +73,56 @@ const EpisodeCardCreate: React.FC = () => {
       `${window.location.origin}/create-card?meetupId=${meetupId}&episode=${episodeNumber}`,
     [episodeNumber, meetupId]
   );
+
+  const displayText = text.trim() || '写下此刻值得留下的想法。';
+  const weightedLength =
+    Array.from(displayText).length +
+    Math.max(0, displayText.split('\n').length - 1) * 12;
+  const hasLongText = weightedLength > 125;
+
+  useLayoutEffect(() => {
+    const container = mainContentRef.current;
+    const quote = quoteRef.current;
+    if (!container || !quote) return;
+
+    let animationFrame = 0;
+
+    const fitText = () => {
+      const initialSize =
+        weightedLength > 180
+          ? 20
+          : weightedLength > 125
+            ? 24
+            : weightedLength > 72
+              ? 31
+              : 42;
+      const minimumSize = photo && photoMode === 'illustration' ? 12 : 14;
+      let fontSize = initialSize;
+
+      quote.style.fontSize = `${fontSize}px`;
+      quote.style.lineHeight = weightedLength > 180 ? '1.4' : '1.5';
+
+      while (
+        container.scrollHeight > container.clientHeight &&
+        fontSize > minimumSize
+      ) {
+        fontSize -= 1;
+        quote.style.fontSize = `${fontSize}px`;
+      }
+    };
+
+    animationFrame = window.requestAnimationFrame(fitText);
+    const observer = new ResizeObserver(() => {
+      window.cancelAnimationFrame(animationFrame);
+      animationFrame = window.requestAnimationFrame(fitText);
+    });
+    observer.observe(container);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      observer.disconnect();
+    };
+  }, [displayText, weightedLength, photo, photoMode, showEpisodeInfo]);
 
   const handlePhoto = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -127,7 +186,7 @@ const EpisodeCardCreate: React.FC = () => {
         await navigator.share({
           files: [file],
           title: `启发星球 EP${episode?.episode_number}`,
-          text: '这是我从这次相遇里带走的一句话。',
+          text: '这是我想记录下来的一点启发。',
         });
       } else {
         saveImageDataUrl(canvas.toDataURL('image/png'), file.name);
@@ -168,27 +227,14 @@ const EpisodeCardCreate: React.FC = () => {
       })
     : '';
   const usesBackgroundPhoto = photo && photoMode !== 'illustration';
-  const displayText = text.trim() || '你想从这次相遇带走什么？';
-  const weightedLength =
-    Array.from(displayText).length +
-    Math.max(0, displayText.split('\n').length - 1) * 12;
-  const quoteSizeClass =
-    weightedLength > 180
-      ? styles.quoteXSmall
-      : weightedLength > 125
-        ? styles.quoteSmall
-        : weightedLength > 72
-          ? styles.quoteMedium
-          : styles.quoteLarge;
-  const hasLongText = weightedLength > 125;
 
   return (
     <main className={styles.page}>
       <section className={styles.editor}>
         <p className={styles.eyebrow}>启发星球 EP{episode.episode_number}</p>
-        <h1>这次相遇，你想带走什么？</h1>
+        <h1>你想记录下什么？</h1>
         <p className={styles.description}>
-          写下一句话、一段感受，或者一个接下来想做的行动。
+          无论是现场参与、听完回放，还是后来想到的，都可以写下来。
         </p>
 
         {error && <Alert severity="warning">{error}</Alert>}
@@ -197,12 +243,12 @@ const EpisodeCardCreate: React.FC = () => {
           value={text}
           maxLength={MAX_TEXT_LENGTH}
           onChange={(event) => setText(event.target.value)}
-          placeholder="不需要整理成完整答案，写下此刻想到的就好……"
+          placeholder="一句话、一段感受，或者一个接下来想做的行动……"
           className={styles.textarea}
           autoFocus
         />
         <div className={styles.counter}>
-          {text.length}/{MAX_TEXT_LENGTH} · 卡片会自动调整字号
+          {text.length}/{MAX_TEXT_LENGTH} · 卡片会根据可用空间自动缩放
         </div>
 
         <label className={styles.photoButton}>
@@ -250,7 +296,7 @@ const EpisodeCardCreate: React.FC = () => {
               checked={showEpisodeInfo}
               onChange={(_, value) => setShowEpisodeInfo(value)}
             />
-            显示本期信息
+            显示期次与主题
           </label>
           <p className={styles.qrNote}>
             邀请二维码会固定保留，让看到卡片的人也能写下自己的启发。
@@ -275,6 +321,7 @@ const EpisodeCardCreate: React.FC = () => {
           {usesBackgroundPhoto && <div className={styles.overlay} />}
           <div className={styles.cardContent}>
             <div
+              ref={mainContentRef}
               className={`${styles.mainContent} ${
                 photo && photoMode === 'illustration'
                   ? styles.mainContentWithIllustration
@@ -290,15 +337,14 @@ const EpisodeCardCreate: React.FC = () => {
                   }`}
                 />
               )}
-              <div className={`${styles.quote} ${quoteSizeClass}`}>
+              <div ref={quoteRef} className={styles.quote}>
                 {displayText}
               </div>
             </div>
             <div className={styles.cardFooter}>
               {showEpisodeInfo ? (
                 <div className={styles.episodeInfo}>
-                  <strong>启发星球 EP{episode.episode_number}</strong>
-                  <span>{cardTitle}</span>
+                  <strong>EP{episode.episode_number} · {cardTitle}</strong>
                   {dateLabel && <span>{dateLabel}</span>}
                 </div>
               ) : (

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -13,10 +13,12 @@ import { useSearchParams } from 'react-router-dom';
 
 import { episodesApi } from '@/netlify/config';
 import { EpisodeCardContext } from '@/netlify/functions/episodes';
+import { getUserName } from '@/utils';
 import { saveImageDataUrl } from '@/utils/share';
 import styles from './episodeCardCreate.module.css';
 
 const MAX_TEXT_LENGTH = 240;
+const MAX_AUTHOR_LENGTH = 24;
 const DEFAULT_INSPIRE_PLANET_MEETUP_ID = 39;
 
 type PhotoMode = 'cover' | 'contain';
@@ -34,6 +36,7 @@ const EpisodeCardCreate: React.FC = () => {
   const quoteRef = useRef<HTMLDivElement>(null);
   const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
   const [text, setText] = useState('');
+  const [author, setAuthor] = useState(() => getUserName() || '');
   const [photo, setPhoto] = useState<string | null>(null);
   const [photoMode, setPhotoMode] = useState<PhotoMode>('cover');
   const [showEpisodeInfo, setShowEpisodeInfo] = useState(true);
@@ -75,6 +78,7 @@ const EpisodeCardCreate: React.FC = () => {
   );
 
   const displayText = text.trim() || '写下此刻值得留下的想法。';
+  const displayAuthor = author.trim() || '匿名';
   const weightedLength =
     Array.from(displayText).length +
     Math.max(0, displayText.split('\n').length - 1) * 12;
@@ -110,7 +114,7 @@ const EpisodeCardCreate: React.FC = () => {
 
     const animationFrame = window.requestAnimationFrame(fitText);
     return () => window.cancelAnimationFrame(animationFrame);
-  }, [displayText, weightedLength, photo, photoMode, showEpisodeInfo]);
+  }, [displayText, weightedLength, photo, photoMode, showEpisodeInfo, author]);
 
   const handlePhoto = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -174,7 +178,7 @@ const EpisodeCardCreate: React.FC = () => {
         await navigator.share({
           files: [file],
           title: `启发星球 EP${episode?.episode_number}`,
-          text: '这是我想记录下来的一点启发。',
+          text: `这是 ${displayAuthor} 想记录下来的一点启发。`,
         });
       } else {
         saveImageDataUrl(canvas.toDataURL('image/png'), file.name);
@@ -237,6 +241,18 @@ const EpisodeCardCreate: React.FC = () => {
         <div className={styles.counter}>
           {text.length}/{MAX_TEXT_LENGTH} · 卡片会根据可用空间自动缩放
         </div>
+
+        <label className={styles.authorField}>
+          <span>署名</span>
+          <input
+            type="text"
+            value={author}
+            maxLength={MAX_AUTHOR_LENGTH}
+            onChange={(event) => setAuthor(event.target.value)}
+            placeholder="你的名字或昵称"
+          />
+          <small>留空时显示“匿名”</small>
+        </label>
 
         <label className={styles.photoButton}>
           ＋ 添加一张照片（可选）
@@ -303,6 +319,7 @@ const EpisodeCardCreate: React.FC = () => {
               <div ref={quoteRef} className={styles.quote}>
                 {displayText}
               </div>
+              <div className={styles.byline}>— {displayAuthor}</div>
             </div>
 
             {showEpisodeInfo ? (

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -19,7 +19,7 @@ import styles from './episodeCardCreate.module.css';
 const MAX_TEXT_LENGTH = 240;
 const DEFAULT_INSPIRE_PLANET_MEETUP_ID = 39;
 
-type PhotoMode = 'cover' | 'contain' | 'illustration';
+type PhotoMode = 'soft' | 'contain';
 
 const EpisodeCardCreate: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -35,7 +35,7 @@ const EpisodeCardCreate: React.FC = () => {
   const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
   const [text, setText] = useState('');
   const [photo, setPhoto] = useState<string | null>(null);
-  const [photoMode, setPhotoMode] = useState<PhotoMode>('cover');
+  const [photoMode, setPhotoMode] = useState<PhotoMode>('soft');
   const [showEpisodeInfo, setShowEpisodeInfo] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
@@ -94,7 +94,6 @@ const EpisodeCardCreate: React.FC = () => {
             : weightedLength > 72
               ? 31
               : 42;
-      const minimumSize = photo && photoMode === 'illustration' ? 12 : 14;
       let fontSize = initialSize;
 
       quote.style.fontSize = `${fontSize}px`;
@@ -102,7 +101,7 @@ const EpisodeCardCreate: React.FC = () => {
 
       while (
         container.scrollHeight > container.clientHeight &&
-        fontSize > minimumSize
+        fontSize > 14
       ) {
         fontSize -= 1;
         quote.style.fontSize = `${fontSize}px`;
@@ -110,13 +109,7 @@ const EpisodeCardCreate: React.FC = () => {
     };
 
     const animationFrame = window.requestAnimationFrame(fitText);
-    const image = container.querySelector('img');
-    image?.addEventListener('load', fitText);
-
-    return () => {
-      window.cancelAnimationFrame(animationFrame);
-      image?.removeEventListener('load', fitText);
-    };
+    return () => window.cancelAnimationFrame(animationFrame);
   }, [displayText, weightedLength, photo, photoMode, showEpisodeInfo]);
 
   const handlePhoto = (event: ChangeEvent<HTMLInputElement>) => {
@@ -221,7 +214,6 @@ const EpisodeCardCreate: React.FC = () => {
         day: 'numeric',
       })
     : '';
-  const usesBackgroundPhoto = photo && photoMode !== 'illustration';
 
   return (
     <main className={styles.page}>
@@ -255,24 +247,17 @@ const EpisodeCardCreate: React.FC = () => {
             <div className={styles.photoModes} aria-label="照片展示方式">
               <button
                 type="button"
-                className={photoMode === 'cover' ? styles.activeMode : ''}
-                onClick={() => setPhotoMode('cover')}
+                className={photoMode === 'soft' ? styles.activeMode : ''}
+                onClick={() => setPhotoMode('soft')}
               >
-                铺满裁切
+                柔和底图
               </button>
               <button
                 type="button"
                 className={photoMode === 'contain' ? styles.activeMode : ''}
                 onClick={() => setPhotoMode('contain')}
               >
-                完整显示
-              </button>
-              <button
-                type="button"
-                className={photoMode === 'illustration' ? styles.activeMode : ''}
-                onClick={() => setPhotoMode('illustration')}
-              >
-                作为插图
+                完整底图
               </button>
             </div>
             <button
@@ -302,36 +287,19 @@ const EpisodeCardCreate: React.FC = () => {
       <section className={styles.previewSection}>
         <div
           ref={previewRef}
-          className={`${styles.card} ${
-            usesBackgroundPhoto ? styles.cardWithPhoto : ''
-          } ${photoMode === 'contain' ? styles.photoContain : ''} ${
-            hasLongText ? styles.cardLongText : ''
-          }`}
-          style={
-            usesBackgroundPhoto
-              ? { backgroundImage: `url(${photo})` }
-              : undefined
-          }
+          className={`${styles.card} ${photo ? styles.cardWithPhoto : ''} ${
+            photoMode === 'contain' ? styles.photoContain : ''
+          } ${hasLongText ? styles.cardLongText : ''}`}
         >
-          {usesBackgroundPhoto && <div className={styles.overlay} />}
-          <div className={styles.cardContent}>
+          {photo && (
             <div
-              ref={mainContentRef}
-              className={`${styles.mainContent} ${
-                photo && photoMode === 'illustration'
-                  ? styles.mainContentWithIllustration
-                  : ''
-              }`}
-            >
-              {photo && photoMode === 'illustration' && (
-                <img
-                  src={photo}
-                  alt="用户选择的插图"
-                  className={`${styles.illustration} ${
-                    hasLongText ? styles.illustrationCompact : ''
-                  }`}
-                />
-              )}
+              className={styles.photoLayer}
+              style={{ backgroundImage: `url(${photo})` }}
+            />
+          )}
+          {photo && <div className={styles.overlay} />}
+          <div className={styles.cardContent}>
+            <div ref={mainContentRef} className={styles.mainContent}>
               <div ref={quoteRef} className={styles.quote}>
                 {displayText}
               </div>
@@ -343,7 +311,10 @@ const EpisodeCardCreate: React.FC = () => {
                   {dateLabel && <span>{dateLabel}</span>}
                 </div>
               ) : (
-                <div className={styles.brandMark}>启发星球</div>
+                <div className={styles.brandBlock}>
+                  <strong>启发星球</strong>
+                  <span>记录启发，也邀请更多人写下自己的想法</span>
+                </div>
               )}
               <div className={styles.qrBlock}>
                 <QRCodeSVG value={shareUrl} size={74} bgColor="#ffffff" />

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -291,7 +291,7 @@ const EpisodeCardCreate: React.FC = () => {
             顶部显示期次
           </label>
           <p className={styles.qrNote}>
-            二维码会融入正文排版，让看到卡片的人也能继续写下自己的启发。
+            二维码固定在卡片右下角，作为邀请其他人继续表达的回应印章。
           </p>
         </div>
       </section>
@@ -304,10 +304,18 @@ const EpisodeCardCreate: React.FC = () => {
           } ${hasLongText ? styles.cardLongText : ''}`}
         >
           {photo && (
-            <div
-              className={styles.photoLayer}
-              style={{ backgroundImage: `url(${photo})` }}
-            />
+            <>
+              <div
+                className={styles.photoLayer}
+                style={{ backgroundImage: `url(${photo})` }}
+              />
+              {photoMode === 'contain' && (
+                <div
+                  className={styles.photoForeground}
+                  style={{ backgroundImage: `url(${photo})` }}
+                />
+              )}
+            </>
           )}
           {photo && <div className={styles.overlay} />}
           <div className={styles.cardContent}>

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -19,7 +19,7 @@ import styles from './episodeCardCreate.module.css';
 const MAX_TEXT_LENGTH = 240;
 const DEFAULT_INSPIRE_PLANET_MEETUP_ID = 39;
 
-type PhotoMode = 'soft' | 'contain';
+type PhotoMode = 'cover' | 'contain';
 
 const EpisodeCardCreate: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -35,7 +35,7 @@ const EpisodeCardCreate: React.FC = () => {
   const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
   const [text, setText] = useState('');
   const [photo, setPhoto] = useState<string | null>(null);
-  const [photoMode, setPhotoMode] = useState<PhotoMode>('soft');
+  const [photoMode, setPhotoMode] = useState<PhotoMode>('cover');
   const [showEpisodeInfo, setShowEpisodeInfo] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
@@ -247,17 +247,17 @@ const EpisodeCardCreate: React.FC = () => {
             <div className={styles.photoModes} aria-label="照片展示方式">
               <button
                 type="button"
-                className={photoMode === 'soft' ? styles.activeMode : ''}
-                onClick={() => setPhotoMode('soft')}
+                className={photoMode === 'cover' ? styles.activeMode : ''}
+                onClick={() => setPhotoMode('cover')}
               >
-                柔和底图
+                铺满画面
               </button>
               <button
                 type="button"
                 className={photoMode === 'contain' ? styles.activeMode : ''}
                 onClick={() => setPhotoMode('contain')}
               >
-                完整底图
+                完整显示
               </button>
             </div>
             <button
@@ -304,23 +304,28 @@ const EpisodeCardCreate: React.FC = () => {
                 {displayText}
               </div>
             </div>
-            <div className={styles.cardFooter}>
-              {showEpisodeInfo ? (
+
+            {showEpisodeInfo ? (
+              <div className={styles.signatureBar}>
                 <div className={styles.episodeInfo}>
-                  <strong>EP{episode.episode_number} · {cardTitle}</strong>
+                  <span className={styles.episodeLabel}>EP{episode.episode_number}</span>
+                  <strong>{cardTitle}</strong>
                   {dateLabel && <span>{dateLabel}</span>}
                 </div>
-              ) : (
-                <div className={styles.brandBlock}>
-                  <strong>启发星球</strong>
-                  <span>记录启发，也邀请更多人写下自己的想法</span>
+                <div className={styles.qrInline}>
+                  <QRCodeSVG value={shareUrl} size={58} bgColor="#ffffff" />
+                  <span>扫码写下你的启发</span>
                 </div>
-              )}
-              <div className={styles.qrBlock}>
-                <QRCodeSVG value={shareUrl} size={74} bgColor="#ffffff" />
-                <span>扫码写下你的启发</span>
               </div>
-            </div>
+            ) : (
+              <div className={styles.inviteBadge}>
+                <div className={styles.inviteCopy}>
+                  <strong>启发星球</strong>
+                  <span>也写下你的这一刻</span>
+                </div>
+                <QRCodeSVG value={shareUrl} size={58} bgColor="#ffffff" />
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -1,0 +1,228 @@
+import React, { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Button, CircularProgress, Switch } from '@mui/material';
+import html2canvas from 'html2canvas';
+import { QRCodeSVG } from 'qrcode.react';
+import { useSearchParams } from 'react-router-dom';
+
+import { episodesApi } from '@/netlify/config';
+import { EpisodeCardContext } from '@/netlify/functions/episodes';
+import { saveImageDataUrl } from '@/utils/share';
+import styles from './episodeCardCreate.module.css';
+
+const MAX_TEXT_LENGTH = 180;
+
+const EpisodeCardCreate: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const episodeId = Number(searchParams.get('episodeId'));
+  const previewRef = useRef<HTMLDivElement>(null);
+  const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
+  const [text, setText] = useState('');
+  const [photo, setPhoto] = useState<string | null>(null);
+  const [showEpisodeInfo, setShowEpisodeInfo] = useState(true);
+  const [showQrCode, setShowQrCode] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadEpisode = async () => {
+      if (!episodeId) {
+        setError('缺少有效的期次信息');
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const response = await episodesApi.getById(episodeId);
+        if (!response.success || !response.data?.episode) {
+          throw new Error(response.error || '无法读取本期活动');
+        }
+        setEpisode(response.data.episode);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '无法读取本期活动');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadEpisode();
+  }, [episodeId]);
+
+  const shareUrl = useMemo(
+    () => `${window.location.origin}/create-card?episodeId=${episodeId}`,
+    [episodeId]
+  );
+
+  const handlePhoto = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setError('请选择图片文件');
+      return;
+    }
+    if (file.size > 8 * 1024 * 1024) {
+      setError('图片请控制在 8MB 以内');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      setPhoto(String(reader.result));
+      setError(null);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const renderCanvas = async () => {
+    if (!previewRef.current || !text.trim()) return null;
+    return html2canvas(previewRef.current, {
+      scale: 2,
+      useCORS: true,
+      allowTaint: true,
+      backgroundColor: null,
+      logging: false,
+    });
+  };
+
+  const handleDownload = async () => {
+    setIsExporting(true);
+    try {
+      const canvas = await renderCanvas();
+      if (!canvas) return;
+      saveImageDataUrl(
+        canvas.toDataURL('image/png'),
+        `inspire-planet-ep${episode?.episode_number}-${Date.now()}.png`
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleShare = async () => {
+    setIsExporting(true);
+    try {
+      const canvas = await renderCanvas();
+      if (!canvas) return;
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, 'image/png')
+      );
+      if (!blob) return;
+
+      const file = new File([blob], 'inspire-planet-card.png', {
+        type: 'image/png',
+      });
+      if (navigator.share && navigator.canShare?.({ files: [file] })) {
+        await navigator.share({
+          files: [file],
+          title: `启发星球 EP${episode?.episode_number}`,
+          text: '这是我从这一期带走的一句话。',
+        });
+      } else {
+        saveImageDataUrl(canvas.toDataURL('image/png'), file.name);
+      }
+    } catch (err) {
+      if ((err as DOMException)?.name !== 'AbortError') {
+        setError('分享失败，请先保存图片后再分享');
+      }
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className={styles.state}><CircularProgress /></div>
+    );
+  }
+
+  if (error && !episode) {
+    return <div className={styles.state}><Alert severity="error">{error}</Alert></div>;
+  }
+
+  if (!episode) return null;
+
+  const cardTitle = episode.theme || episode.meetup.title;
+  const dateLabel = new Date(`${episode.date}T00:00:00`).toLocaleDateString(
+    'zh-CN',
+    { year: 'numeric', month: 'long', day: 'numeric' }
+  );
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.editor}>
+        <p className={styles.eyebrow}>启发星球 EP{episode.episode_number}</p>
+        <h1>今晚，你想带走什么？</h1>
+        <p className={styles.description}>
+          写下一句话、一段感受，或者一个接下来想做的行动。
+        </p>
+
+        {error && <Alert severity="warning">{error}</Alert>}
+
+        <textarea
+          value={text}
+          maxLength={MAX_TEXT_LENGTH}
+          onChange={(event) => setText(event.target.value)}
+          placeholder="不需要整理成完整答案，写下此刻想到的就好……"
+          className={styles.textarea}
+          autoFocus
+        />
+        <div className={styles.counter}>{text.length}/{MAX_TEXT_LENGTH}</div>
+
+        <label className={styles.photoButton}>
+          ＋ 添加一张照片（可选）
+          <input type="file" accept="image/*" onChange={handlePhoto} hidden />
+        </label>
+        {photo && (
+          <button className={styles.removePhoto} onClick={() => setPhoto(null)}>
+            移除照片
+          </button>
+        )}
+
+        <div className={styles.settings}>
+          <label><Switch checked={showEpisodeInfo} onChange={(_, value) => setShowEpisodeInfo(value)} />显示本期信息</label>
+          <label><Switch checked={showQrCode} onChange={(_, value) => setShowQrCode(value)} />显示邀请二维码</label>
+        </div>
+      </section>
+
+      <section className={styles.previewSection}>
+        <div
+          ref={previewRef}
+          className={`${styles.card} ${photo ? styles.cardWithPhoto : ''}`}
+          style={photo ? { backgroundImage: `url(${photo})` } : undefined}
+        >
+          {photo && <div className={styles.overlay} />}
+          <div className={styles.cardContent}>
+            <div className={styles.quote}>{text.trim() || '你想从今晚带走什么？'}</div>
+            <div className={styles.cardFooter}>
+              {showEpisodeInfo && (
+                <div className={styles.episodeInfo}>
+                  <strong>启发星球 EP{episode.episode_number}</strong>
+                  <span>{cardTitle}</span>
+                  <span>{dateLabel}</span>
+                </div>
+              )}
+              {showQrCode && (
+                <div className={styles.qrBlock}>
+                  <QRCodeSVG value={shareUrl} size={74} bgColor="#ffffff" />
+                  <span>扫码写下你的启发</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.actions}>
+          <Button variant="contained" size="large" disabled={!text.trim() || isExporting} onClick={handleShare}>
+            {isExporting ? '正在生成…' : '生成并分享'}
+          </Button>
+          <Button variant="outlined" size="large" disabled={!text.trim() || isExporting} onClick={handleDownload}>
+            保存图片
+          </Button>
+        </div>
+        <p className={styles.privacy}>照片只在你的浏览器中处理，不会自动上传。</p>
+      </section>
+    </main>
+  );
+};
+
+export default EpisodeCardCreate;


### PR DESCRIPTION
## What changed

- adds a public episode-card lookup by `meetup_id + episode_number`
- keeps recurring activity series isolated so an episode number cannot resolve to another meetup
- supports `/create-card?meetupId=<meetup>&episode=<number>`
- treats legacy `episodeId` as an episode number for the default Inspire Planet meetup
- allows a card to render even when that episode has not yet been persisted in `meetup_episodes`
- uses a neutral prompt: `你想记录下什么？`
- supports optional author attribution, with the existing site nickname prefilled when available and `匿名` as fallback
- supports up to 500 Chinese characters and automatically reduces text size based on actual available space
- keeps two photo modes: `铺满画面` and `完整显示`
- keeps uploaded photos visually clear and uses only a local text panel for readability
- removes the decorative white border around photo cards
- uses a blurred copy of the same photo behind `完整显示`, avoiding black side gaps while preserving the complete original image
- keeps Inspire Planet / episode metadata as lightweight labels along the top edge
- uses `真实 · 自由 · 不必完整` to express the space’s tone instead of repeating the meetup name
- anchors the QR response stamp to the bottom-right corner for both short and long reflections
- reserves only a compact closing area for the QR stamp when text exceeds 180 characters
- keeps the card body focused on the reflection text and author signature
- exports a high-resolution PNG and uses native file sharing when supported
- preserves the existing generic `/create-card` flow when no episode query parameter is present

## Why

The first preview exposed that database row IDs are not human-facing episode numbers. For example, `meetup_episodes.id = 30` belongs to a roundtable meetup and represents its episode 21. The card URL now identifies both the activity series and displayed episode number.

The card layout was refined through preview testing so it feels more like a warm, shareable magazine quote card and less like a functional poster. Background photos remain recognizable, metadata stays at the visual edge, and the QR code remains discoverable without moving away from the lower-right corner as content grows.

## Recommended URL

```text
/create-card?meetupId=39&episode=30
```

For Inspire Planet, `meetupId=39` is the existing recurring online-sharing meetup.

## Data and privacy

- reads existing `meetups` and `meetup_episodes` data
- does not require login
- does not persist the reflection, author name, or selected photo
- processes the selected photo only in the browser
- the QR code points back to the same meetup and episode

## Validation

- confirmed in Supabase that row `id=30` belongs to meetup 38 and episode 21, explaining the original cross-series result
- reviewed the branch diff against `main`
- verified existing dependencies include `html2canvas` and `qrcode.react`
- preserved unconditional React Hook execution by isolating the generic creator
- confirmed the latest card layout includes top metadata, author attribution, a fixed lower-right QR response stamp, and no white photo border

## Manual checks still needed in deploy preview

- `/create-card?meetupId=39&episode=30` displays Inspire Planet EP30 and never roundtable data
- an episode without a persisted row still renders without a date or custom theme
- both photo modes export correctly
- `完整显示` uses the same photo as a soft full-bleed background without black side gaps
- short, medium, and 500-character Chinese text remain inside the card
- the QR stamp stays in the lower-right corner at every text length
- author attribution fits with short and long names
- QR recognition works on exported cards
- iPhone Safari, Android Chrome, and WeChat save/share behavior