### PR TITLE
Add episode response wall and post-meeting flow

### DIFF
--- a/src/netlify/config/index.ts
+++ b/src/netlify/config/index.ts
@@ -18,6 +18,7 @@ export { default as workshopApi } from '../services/workshop';
 export { default as contactApi } from '../services/contact';
 export { default as surveyApi } from '../services/survey';
 export { default as episodesApi } from '../services/episodes';
+export { default as episodeResponsesApi } from '../services/episodeResponses';
 export { default as speakerSignupsApi } from '../services/speakerSignups';
 export { default as communityQrApi } from '../services/communityQr';
 export { default as submissionsApi } from '../services/submissions';

--- a/src/netlify/functions/episodeResponses.ts
+++ b/src/netlify/functions/episodeResponses.ts
@@ -1,0 +1,143 @@
+import { createHash } from 'crypto';
+
+import { supabase } from '../../database/supabase';
+import { NetlifyContext, NetlifyEvent, NetlifyResponse } from '../types/http';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  getDataFromEvent,
+  getFunctionNameFromEvent,
+  handleOptionsRequest,
+} from '../utils/server';
+import { validateEpisodeResponseInput } from '../validation/episodeResponses';
+
+const MAX_RESPONSES_PER_WINDOW = 5;
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+
+export interface EpisodeResponse {
+  id: number;
+  meetup_id: number;
+  episode_number: number;
+  content: string;
+  author: string;
+  created_at: string;
+}
+
+const getClientFingerprint = (event: NetlifyEvent) => {
+  const ip =
+    event.headers['x-nf-client-connection-ip'] ||
+    event.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+    event.headers['client-ip'];
+  if (!ip) return null;
+
+  const salt =
+    process.env.RESPONSE_RATE_LIMIT_SALT ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    'inspire-planet-response';
+  return createHash('sha256').update(`${salt}:${ip}`).digest('hex');
+};
+
+export async function handler(
+  event: NetlifyEvent,
+  _context: NetlifyContext
+): Promise<NetlifyResponse> {
+  if (event.httpMethod === 'OPTIONS') return handleOptionsRequest();
+
+  try {
+    switch (getFunctionNameFromEvent(event)) {
+      case 'getByEpisode':
+        return await handleGetByEpisode(event);
+      case 'create':
+        return await handleCreate(event);
+      default:
+        return createErrorResponse('无效的操作类型');
+    }
+  } catch (error) {
+    console.error('Episode responses handler error:', error);
+    return createErrorResponse('服务器内部错误', 500);
+  }
+}
+
+async function handleGetByEpisode(
+  event: NetlifyEvent
+): Promise<NetlifyResponse> {
+  const validation = validateEpisodeResponseInput(getDataFromEvent(event));
+  if (!validation.ok) return createErrorResponse(validation.error);
+  const { meetupId, episodeNumber } = validation.value;
+
+  const { data, error } = await supabase
+    .from('episode_responses')
+    .select('id, meetup_id, episode_number, content, author, created_at')
+    .eq('meetup_id', meetupId)
+    .eq('episode_number', episodeNumber)
+    .eq('status', 'published')
+    .order('created_at', { ascending: true })
+    .limit(100);
+
+  if (error) {
+    console.error('Get episode responses error:', error);
+    return createErrorResponse('读取本期回应失败', 500);
+  }
+
+  return createSuccessResponse({ responses: data || [] });
+}
+
+async function handleCreate(event: NetlifyEvent): Promise<NetlifyResponse> {
+  const data = getDataFromEvent(event);
+
+  // Hidden honeypot: bots often fill every field. Return a normal response so
+  // they do not learn how to bypass it, while keeping the wall clean.
+  if (String(data.website || '').trim()) {
+    return createSuccessResponse({ response: null }, 201);
+  }
+
+  const validation = validateEpisodeResponseInput(data, true);
+  if (!validation.ok) return createErrorResponse(validation.error);
+  const { meetupId, episodeNumber, content, author } = validation.value;
+
+  const { data: meetup } = await supabase
+    .from('meetups')
+    .select('id')
+    .eq('id', meetupId)
+    .maybeSingle();
+  if (!meetup) return createErrorResponse('活动不存在', 404);
+
+  const fingerprint = getClientFingerprint(event);
+  if (fingerprint) {
+    const windowStart = new Date(
+      Date.now() - RATE_LIMIT_WINDOW_MS
+    ).toISOString();
+    const { count, error: countError } = await supabase
+      .from('episode_responses')
+      .select('id', { count: 'exact', head: true })
+      .eq('request_fingerprint', fingerprint)
+      .gte('created_at', windowStart);
+
+    if (countError) {
+      console.error('Episode response rate limit error:', countError);
+      return createErrorResponse('暂时无法发布，请稍后再试', 500);
+    }
+    if ((count || 0) >= MAX_RESPONSES_PER_WINDOW) {
+      return createErrorResponse('发布得有点快，请稍后再试', 429);
+    }
+  }
+
+  const { data: created, error } = await supabase
+    .from('episode_responses')
+    .insert({
+      meetup_id: meetupId,
+      episode_number: episodeNumber,
+      content,
+      author,
+      request_fingerprint: fingerprint,
+    })
+    .select('id, meetup_id, episode_number, content, author, created_at')
+    .single();
+
+  if (error) {
+    console.error('Create episode response error:', error);
+    return createErrorResponse('发布失败，请稍后再试', 500);
+  }
+
+  return createSuccessResponse({ response: created }, 201);
+}

--- a/src/netlify/services/episodeResponses.ts
+++ b/src/netlify/services/episodeResponses.ts
@@ -1,0 +1,26 @@
+import { http } from '../config/http';
+import { ApiResponse } from '../types/http';
+import { EpisodeResponse } from '../functions/episodeResponses';
+
+export const episodeResponsesApi = {
+  getByEpisode: async (
+    meetupId: number,
+    episodeNumber: number
+  ): Promise<ApiResponse<{ responses: EpisodeResponse[] }>> =>
+    http.get('/episodeResponses', 'getByEpisode', {
+      meetup_id: meetupId,
+      episode_number: episodeNumber,
+    }),
+
+  create: async (data: {
+    meetup_id: number;
+    episode_number: number;
+    content: string;
+    author: string;
+    publish_consent: boolean;
+    website?: string;
+  }): Promise<ApiResponse<{ response: EpisodeResponse | null }>> =>
+    http.post('/episodeResponses', 'create', data),
+};
+
+export default episodeResponsesApi;

--- a/src/netlify/validation/episodeResponses.test.ts
+++ b/src/netlify/validation/episodeResponses.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_RESPONSE_CONTENT_LENGTH,
+  validateEpisodeResponseInput,
+} from './episodeResponses';
+
+describe('validateEpisodeResponseInput', () => {
+  it('normalizes a valid public response', () => {
+    expect(
+      validateEpisodeResponseInput(
+        {
+          meetup_id: '39',
+          episode_number: '30',
+          content: '  我想把这一句留下来。  ',
+          author: '  星友  ',
+          publish_consent: true,
+        },
+        true
+      )
+    ).toEqual({
+      ok: true,
+      value: {
+        meetupId: 39,
+        episodeNumber: 30,
+        content: '我想把这一句留下来。',
+        author: '星友',
+      },
+    });
+  });
+
+  it('requires explicit consent before publishing', () => {
+    const result = validateEpisodeResponseInput(
+      {
+        meetup_id: 39,
+        episode_number: 30,
+        content: '一句回应',
+      },
+      true
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('counts unicode characters instead of UTF-16 code units', () => {
+    const result = validateEpisodeResponseInput(
+      {
+        meetup_id: 39,
+        episode_number: 30,
+        content: '🌱'.repeat(MAX_RESPONSE_CONTENT_LENGTH),
+        publish_consent: true,
+      },
+      true
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an overlong response', () => {
+    const result = validateEpisodeResponseInput(
+      {
+        meetup_id: 39,
+        episode_number: 30,
+        content: '字'.repeat(MAX_RESPONSE_CONTENT_LENGTH + 1),
+        publish_consent: true,
+      },
+      true
+    );
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/netlify/validation/episodeResponses.ts
+++ b/src/netlify/validation/episodeResponses.ts
@@ -1,0 +1,61 @@
+export const MAX_RESPONSE_CONTENT_LENGTH = 500;
+export const MAX_RESPONSE_AUTHOR_LENGTH = 24;
+
+export type EpisodeResponseInput = {
+  meetupId: number;
+  episodeNumber: number;
+  content: string;
+  author: string;
+};
+
+export type EpisodeResponseValidation =
+  { ok: true; value: EpisodeResponseInput } | { ok: false; error: string };
+
+export const validateEpisodeResponseInput = (
+  data: Record<string, unknown>,
+  requireConsent = false
+): EpisodeResponseValidation => {
+  const meetupId = Number(data.meetup_id);
+  const episodeNumber = Number(data.episode_number);
+
+  if (
+    !Number.isInteger(meetupId) ||
+    meetupId <= 0 ||
+    !Number.isInteger(episodeNumber) ||
+    episodeNumber <= 0
+  ) {
+    return { ok: false, error: '缺少有效的活动或期数' };
+  }
+
+  if (requireConsent && data.publish_consent !== true) {
+    return { ok: false, error: '请确认愿意将内容公开到本期回应墙' };
+  }
+
+  const content = String(data.content || '').trim();
+  const author = String(data.author || '').trim() || '匿名';
+
+  if (
+    requireConsent &&
+    (!content || Array.from(content).length > MAX_RESPONSE_CONTENT_LENGTH)
+  ) {
+    return {
+      ok: false,
+      error: `回应需为 1-${MAX_RESPONSE_CONTENT_LENGTH} 个字符`,
+    };
+  }
+
+  if (
+    requireConsent &&
+    Array.from(author).length > MAX_RESPONSE_AUTHOR_LENGTH
+  ) {
+    return {
+      ok: false,
+      error: `署名不能超过 ${MAX_RESPONSE_AUTHOR_LENGTH} 个字符`,
+    };
+  }
+
+  return {
+    ok: true,
+    value: { meetupId, episodeNumber, content, author },
+  };
+};

--- a/src/pages/card/CardCreate/index.tsx
+++ b/src/pages/card/CardCreate/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import html2canvas from 'html2canvas';
 
 import { CardItem } from '../../../netlify/types';
@@ -8,7 +8,6 @@ import { useGlobalSnackbar } from '@/context/app';
 import { getUserId } from '@/utils/user';
 import { gradientOptions } from '@/constants/gradient';
 import EditForm, { EditFormRef } from '../components/EditForm';
-import EpisodeCardCreate from '../EpisodeCardCreate';
 import { getUserName } from '../../../utils';
 import { isMobileBrowser, saveImageDataUrl } from '@/utils/share';
 
@@ -105,12 +104,6 @@ const StandardCardCreate: React.FC = () => {
   );
 };
 
-const CreateCard: React.FC = () => {
-  const [searchParams] = useSearchParams();
-  const hasEpisodeContext =
-    searchParams.has('episode') || searchParams.has('episodeId');
-
-  return hasEpisodeContext ? <EpisodeCardCreate /> : <StandardCardCreate />;
-};
+const CreateCard: React.FC = () => <StandardCardCreate />;
 
 export default CreateCard;

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -71,27 +71,6 @@
   color: #6f675f;
 }
 
-.theme {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  margin: 2px 0 4px;
-  padding: 10px 12px;
-  border-radius: 12px;
-  color: #5b4438;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  background: #fff4e8;
-}
-
-.theme span {
-  flex-shrink: 0;
-  color: #b45b35;
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-}
-
 .textarea {
   min-height: 136px;
   border: 1px solid #ded4c9;
@@ -384,12 +363,6 @@
   color: rgba(82, 62, 51, 0.76);
   font-size: 0.7rem;
   line-height: 1.35;
-}
-
-.episodeDetails strong {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .episodeDetails span {

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -179,6 +179,10 @@
   color: #d86f42;
 }
 
+.publishPanel :global(.MuiCheckbox-root.Mui-checked) {
+  color: #d86f42;
+}
+
 .publishPanel small {
   padding-left: 32px;
   color: #8d8379;
@@ -189,6 +193,15 @@
   margin-top: 2px;
   border-radius: 12px;
   box-shadow: none;
+}
+
+.publishPanel :global(.MuiButton-contained:not(.Mui-disabled)) {
+  background: #e56f45;
+  color: #fff;
+}
+
+.publishPanel :global(.MuiButton-contained:not(.Mui-disabled):hover) {
+  background: #ca5c36;
 }
 
 .wallLink,

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -81,9 +81,67 @@
   background: #fff;
 }
 
+.textarea:disabled,
+.authorField input:disabled {
+  background: #f8f3ee;
+  color: #514a44;
+  opacity: 1;
+}
+
 .authorField small {
   grid-column: 2;
   color: #8d8379;
+}
+
+.honeypot {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.publishPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid #eadfd4;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.publishPanel :global(.MuiFormControlLabel-root) {
+  align-items: flex-start;
+  margin: 0;
+}
+
+.publishPanel :global(.MuiCheckbox-root) {
+  padding: 2px 8px 2px 0;
+  color: #d86f42;
+}
+
+.publishPanel small {
+  padding-left: 32px;
+  color: #8d8379;
+  line-height: 1.5;
+}
+
+.wallLink,
+.inlineLink {
+  color: #a94e2b;
+  font-weight: 650;
+}
+
+.wallLink {
+  align-self: center;
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.wallLink:hover,
+.inlineLink:hover {
+  text-decoration: underline;
 }
 
 .photoButton,
@@ -151,7 +209,11 @@
   border-radius: 28px;
   color: #4c3529;
   background:
-    radial-gradient(circle at 18% 15%, rgba(255, 255, 255, 0.72), transparent 28%),
+    radial-gradient(
+      circle at 18% 15%,
+      rgba(255, 255, 255, 0.72),
+      transparent 28%
+    ),
     linear-gradient(145deg, #fff4dc, #f7c8aa 55%, #df8c6a);
   box-shadow: 0 18px 50px rgba(87, 53, 36, 0.16);
 }

--- a/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
+++ b/src/pages/card/EpisodeCardCreate/episodeCardCreate.module.css
@@ -1,30 +1,67 @@
 .page {
   min-height: calc(100vh - 64px);
-  padding: 40px 20px 64px;
+  padding: 28px 20px 48px;
   display: grid;
-  grid-template-columns: minmax(0, 420px) minmax(320px, 520px);
+  grid-template-columns: minmax(0, 410px) minmax(320px, 480px);
   justify-content: center;
-  gap: 48px;
-  background: #fffaf5;
+  align-items: start;
+  gap: 32px;
+  background:
+    radial-gradient(
+      circle at 76% 12%,
+      rgba(244, 185, 148, 0.18),
+      transparent 30%
+    ),
+    #fffaf5;
 }
 
 .editor,
 .previewSection {
   display: flex;
   flex-direction: column;
+  gap: 12px;
+}
+
+.editor {
+  padding: 24px;
+  border: 1px solid #eadfd4;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 16px 42px rgba(91, 58, 42, 0.08);
+}
+
+.episodeContext,
+.previewHeading,
+.settingsHeading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 16px;
 }
 
-.eyebrow {
-  margin: 0;
+.episodeContext a {
   color: #d86f42;
   font-weight: 700;
   letter-spacing: 0.08em;
+  text-decoration: none;
+}
+
+.episodeContext a:hover {
+  text-decoration: underline;
+}
+
+.episodeContext span,
+.previewHeading span,
+.settingsHeading span {
+  color: #94877d;
+  font-size: 0.8rem;
 }
 
 .editor h1 {
   margin: 0;
-  font-size: clamp(2rem, 5vw, 3rem);
+  font-family: var(--font-serif);
+  font-size: clamp(1.9rem, 4vw, 2.55rem);
+  font-weight: 650;
   line-height: 1.12;
 }
 
@@ -34,14 +71,35 @@
   color: #6f675f;
 }
 
+.theme {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin: 2px 0 4px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: #5b4438;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  background: #fff4e8;
+}
+
+.theme span {
+  flex-shrink: 0;
+  color: #b45b35;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
 .textarea {
-  min-height: 180px;
+  min-height: 136px;
   border: 1px solid #ded4c9;
-  border-radius: 18px;
-  padding: 18px;
+  border-radius: 16px;
+  padding: 15px 16px;
   font: inherit;
-  font-size: 1.05rem;
-  line-height: 1.7;
+  font-size: 1rem;
+  line-height: 1.65;
   resize: vertical;
   background: white;
 }
@@ -53,7 +111,7 @@
 }
 
 .counter {
-  margin-top: -10px;
+  margin-top: -7px;
   text-align: right;
   color: #8d8379;
   font-size: 0.82rem;
@@ -76,7 +134,7 @@
   min-width: 0;
   border: 1px solid #ded4c9;
   border-radius: 12px;
-  padding: 10px 12px;
+  padding: 9px 11px;
   font: inherit;
   background: #fff;
 }
@@ -104,8 +162,8 @@
 .publishPanel {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 16px;
+  gap: 8px;
+  padding: 14px;
   border: 1px solid #eadfd4;
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.76);
@@ -125,6 +183,12 @@
   padding-left: 32px;
   color: #8d8379;
   line-height: 1.5;
+}
+
+.publishPanel :global(.MuiButton-root) {
+  margin-top: 2px;
+  border-radius: 12px;
+  box-shadow: none;
 }
 
 .wallLink,
@@ -179,26 +243,35 @@
   font-weight: 700;
 }
 
-.settings {
+.cardSettings {
   display: flex;
   flex-direction: column;
-  padding-top: 8px;
-  border-top: 1px solid #eadfd4;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid #eadfd4;
+  border-radius: 16px;
+  background: #fffaf6;
 }
 
-.settings label {
+.cardSettings label {
   display: flex;
   align-items: center;
   color: #514a44;
 }
 
-.qrNote {
-  margin: 2px 0 0;
-  padding-left: 12px;
-  border-left: 3px solid #efb08f;
-  color: #756b62;
-  font-size: 0.86rem;
-  line-height: 1.55;
+.settingsHeading strong,
+.previewHeading strong {
+  color: #514a44;
+  font-size: 0.9rem;
+}
+
+.previewSection {
+  position: sticky;
+  top: 82px;
+}
+
+.previewHeading {
+  min-height: 24px;
 }
 
 .card {
@@ -280,6 +353,39 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+}
+
+.episodeMeta {
+  display: flex;
+  min-width: 0;
+  max-width: 64%;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.episodeDetails {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  color: rgba(82, 62, 51, 0.76);
+  font-size: 0.7rem;
+  line-height: 1.35;
+}
+
+.episodeDetails strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.episodeDetails span {
+  font-size: 0.64rem;
+}
+
+.cardWithPhoto .episodeDetails {
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.28);
 }
 
 .brandChip {
@@ -436,6 +542,18 @@
   gap: 12px;
 }
 
+.actions :global(.MuiButton-root) {
+  min-height: 44px;
+  border-radius: 12px;
+  box-shadow: none;
+}
+
+.privacy {
+  font-size: 0.8rem;
+  line-height: 1.55;
+  text-align: center;
+}
+
 .state {
   min-height: 60vh;
   display: grid;
@@ -446,11 +564,25 @@
 @media (max-width: 820px) {
   .page {
     grid-template-columns: 1fr;
-    padding: 24px 16px 48px;
-    gap: 30px;
+    padding: 16px 14px 36px;
+    gap: 24px;
+  }
+
+  .editor {
+    padding: 18px;
+    border-radius: 20px;
+  }
+
+  .editor h1 {
+    font-size: 2rem;
+  }
+
+  .textarea {
+    min-height: 128px;
   }
 
   .previewSection {
+    position: static;
     width: min(100%, 520px);
     margin: 0 auto;
   }
@@ -481,7 +613,7 @@
   }
 
   .photoModes {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .qrFloat {
@@ -496,6 +628,16 @@
   }
 
   .actions {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .actions {
     grid-template-columns: 1fr;
+  }
+
+  .episodeContext span {
+    display: none;
   }
 }

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -55,6 +55,9 @@ const EpisodeCardCreate: React.FC = () => {
   const [publishedResponseId, setPublishedResponseId] = useState<number | null>(
     null
   );
+  const [publishedResponseDate, setPublishedResponseDate] = useState<
+    string | null
+  >(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
@@ -99,6 +102,13 @@ const EpisodeCardCreate: React.FC = () => {
         day: 'numeric',
       })
     : '';
+  const responseDate = new Date(
+    publishedResponseDate || Date.now()
+  ).toLocaleDateString('zh-CN', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
   const displayText = text.trim() || '写下此刻还留在心里的片段。';
   const displayAuthor = author.trim() || '匿名';
   const weightedLength =
@@ -235,6 +245,7 @@ const EpisodeCardCreate: React.FC = () => {
         throw new Error(response.error || '发布失败，请稍后再试');
       }
       setPublishedResponseId(response.data.response.id);
+      setPublishedResponseDate(response.data.response.created_at);
     } catch (err) {
       setError(err instanceof Error ? err.message : '发布失败，请稍后再试');
     } finally {
@@ -267,7 +278,7 @@ const EpisodeCardCreate: React.FC = () => {
           <Link to={`/episodes/${episodeNumber}`}>
             启发星球 EP{episode.episode_number}
           </Link>
-          <span>约 2 分钟</span>
+          <span>回应日期：{responseDate} · 约 2 分钟</span>
         </div>
         <h1>刚才有什么留在你心里？</h1>
         <p className={styles.description}>
@@ -404,7 +415,7 @@ const EpisodeCardCreate: React.FC = () => {
               checked={showEpisodeInfo}
               onChange={(_, value) => setShowEpisodeInfo(value)}
             />
-            显示期数和日期
+            显示期数、分享日期和回应日期
           </label>
         </div>
       </section>
@@ -444,9 +455,10 @@ const EpisodeCardCreate: React.FC = () => {
                     ? `启发星球 EP${episode.episode_number}`
                     : '启发星球'}
                 </div>
-                {showEpisodeInfo && episodeDate && (
+                {showEpisodeInfo && (
                   <div className={styles.episodeDetails}>
-                    <span>{episodeDate}</span>
+                    {episodeDate && <span>分享日期 · {episodeDate}</span>}
+                    <span>回应日期 · {responseDate}</span>
                   </div>
                 )}
               </div>

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/material';
 import html2canvas from 'html2canvas';
 import { QRCodeSVG } from 'qrcode.react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 
 import { episodeResponsesApi, episodesApi } from '@/netlify/config';
 import { EpisodeCardContext } from '@/netlify/functions/episodes';
@@ -31,9 +31,12 @@ const DEFAULT_INSPIRE_PLANET_MEETUP_ID = 39;
 type PhotoMode = 'cover' | 'contain';
 
 const EpisodeCardCreate: React.FC = () => {
+  const params = useParams<{ episode: string }>();
   const [searchParams] = useSearchParams();
   const episodeNumber = Number(
-    searchParams.get('episode') || searchParams.get('episodeId')
+    params.episode ||
+      searchParams.get('episode') ||
+      searchParams.get('episodeId')
   );
   const meetupId = Number(
     searchParams.get('meetupId') || DEFAULT_INSPIRE_PLANET_MEETUP_ID
@@ -85,10 +88,18 @@ const EpisodeCardCreate: React.FC = () => {
   }, [episodeNumber, meetupId]);
 
   const shareUrl = useMemo(
-    () =>
-      `${window.location.origin}/create-card?meetupId=${meetupId}&episode=${episodeNumber}`,
-    [episodeNumber, meetupId]
+    () => `${window.location.origin}/episodes/${episodeNumber}/respond`,
+    [episodeNumber]
   );
+
+  const episodeDate = episode?.date
+    ? new Date(`${episode.date}T00:00:00`).toLocaleDateString('zh-CN', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : '';
+  const episodeTheme = episode?.theme || episode?.meetup.default_theme || '';
 
   const displayText = text.trim() || '写下此刻值得留下的想法。';
   const displayAuthor = author.trim() || '匿名';
@@ -254,11 +265,23 @@ const EpisodeCardCreate: React.FC = () => {
   return (
     <main className={styles.page}>
       <section className={styles.editor}>
-        <p className={styles.eyebrow}>启发星球 EP{episode.episode_number}</p>
-        <h1>你想记录下什么？</h1>
+        <div className={styles.episodeContext}>
+          <Link to={`/episodes/${episodeNumber}`}>
+            启发星球 EP{episode.episode_number}
+          </Link>
+          <span>约 2 分钟</span>
+        </div>
+        <h1>写下一句，留在本期</h1>
         <p className={styles.description}>
-          不必完整。写下一句此刻还留在你心里的话，和本期星友彼此照亮。
+          不必总结整场分享，只写此刻还留在你心里的话。
         </p>
+
+        {episodeTheme && (
+          <p className={styles.theme}>
+            <span>本期主题</span>
+            {episodeTheme}
+          </p>
+        )}
 
         {error && <Alert severity="warning">{error}</Alert>}
 
@@ -272,7 +295,7 @@ const EpisodeCardCreate: React.FC = () => {
           autoFocus
         />
         <div className={styles.counter}>
-          {text.length}/{MAX_TEXT_LENGTH} · 卡片会根据可用空间自动缩放
+          {text.length}/{MAX_TEXT_LENGTH}
         </div>
 
         <label className={styles.authorField}>
@@ -285,7 +308,7 @@ const EpisodeCardCreate: React.FC = () => {
             placeholder="你的名字或昵称"
             disabled={Boolean(publishedResponseId)}
           />
-          <small>留空时显示“匿名”</small>
+          <small>可以留空，卡片会显示“匿名”</small>
         </label>
 
         <label className={styles.honeypot} aria-hidden="true">
@@ -310,7 +333,7 @@ const EpisodeCardCreate: React.FC = () => {
             }
             label="我愿意将这段文字和署名公开到本期回应墙"
           />
-          <small>公开后，任何访问本期页面的人都可以看到。</small>
+          <small>勾选后，文字和署名会直接出现在本期页面。</small>
           <Button
             variant="contained"
             size="large"
@@ -332,7 +355,7 @@ const EpisodeCardCreate: React.FC = () => {
             <Alert severity="success">
               你的回应已经出现在 EP{episode.episode_number} 回应墙。{' '}
               <Link
-                to={`/episode/${meetupId}/${episodeNumber}#responses`}
+                to={`/episodes/${episodeNumber}#responses`}
                 className={styles.inlineLink}
               >
                 去看看大家写了什么
@@ -341,7 +364,7 @@ const EpisodeCardCreate: React.FC = () => {
           )}
           {!publishedResponseId && (
             <Link
-              to={`/episode/${meetupId}/${episodeNumber}#responses`}
+              to={`/episodes/${episodeNumber}#responses`}
               className={styles.wallLink}
             >
               先看看本期回应墙
@@ -349,53 +372,57 @@ const EpisodeCardCreate: React.FC = () => {
           )}
         </div>
 
-        <label className={styles.photoButton}>
-          ＋ 添加一张照片（可选）
-          <input type="file" accept="image/*" onChange={handlePhoto} hidden />
-        </label>
-        {photo && (
-          <>
-            <div className={styles.photoModes} aria-label="照片展示方式">
+        <div className={styles.cardSettings}>
+          <div className={styles.settingsHeading}>
+            <strong>卡片设置</strong>
+            <span>均为可选</span>
+          </div>
+          <label className={styles.photoButton}>
+            ＋ 添加一张照片
+            <input type="file" accept="image/*" onChange={handlePhoto} hidden />
+          </label>
+          {photo && (
+            <>
+              <div className={styles.photoModes} aria-label="照片展示方式">
+                <button
+                  type="button"
+                  className={photoMode === 'cover' ? styles.activeMode : ''}
+                  onClick={() => setPhotoMode('cover')}
+                >
+                  铺满画面
+                </button>
+                <button
+                  type="button"
+                  className={photoMode === 'contain' ? styles.activeMode : ''}
+                  onClick={() => setPhotoMode('contain')}
+                >
+                  完整显示
+                </button>
+              </div>
               <button
                 type="button"
-                className={photoMode === 'cover' ? styles.activeMode : ''}
-                onClick={() => setPhotoMode('cover')}
+                className={styles.removePhoto}
+                onClick={() => setPhoto(null)}
               >
-                铺满画面
+                移除照片
               </button>
-              <button
-                type="button"
-                className={photoMode === 'contain' ? styles.activeMode : ''}
-                onClick={() => setPhotoMode('contain')}
-              >
-                完整显示
-              </button>
-            </div>
-            <button
-              type="button"
-              className={styles.removePhoto}
-              onClick={() => setPhoto(null)}
-            >
-              移除照片
-            </button>
-          </>
-        )}
-
-        <div className={styles.settings}>
+            </>
+          )}
           <label>
             <Switch
               checked={showEpisodeInfo}
               onChange={(_, value) => setShowEpisodeInfo(value)}
             />
-            顶部显示期次
+            显示本期主题、日期和期数
           </label>
-          <p className={styles.qrNote}>
-            二维码固定在卡片右下角，作为邀请其他人继续表达的回应印章。
-          </p>
         </div>
       </section>
 
       <section className={styles.previewSection}>
+        <div className={styles.previewHeading}>
+          <strong>卡片预览</strong>
+          <span>边写边生成</span>
+        </div>
         <div
           ref={previewRef}
           className={`${styles.card} ${photo ? styles.cardWithPhoto : ''} ${
@@ -420,10 +447,18 @@ const EpisodeCardCreate: React.FC = () => {
 
           <div className={styles.cardContent}>
             <div className={styles.topMeta}>
-              <div className={styles.brandChip}>
-                {showEpisodeInfo
-                  ? `启发星球 EP${episode.episode_number}`
-                  : '启发星球'}
+              <div className={styles.episodeMeta}>
+                <div className={styles.brandChip}>
+                  {showEpisodeInfo
+                    ? `启发星球 EP${episode.episode_number}`
+                    : '启发星球'}
+                </div>
+                {showEpisodeInfo && (episodeTheme || episodeDate) && (
+                  <div className={styles.episodeDetails}>
+                    {episodeTheme && <strong>{episodeTheme}</strong>}
+                    {episodeDate && <span>{episodeDate}</span>}
+                  </div>
+                )}
               </div>
               <div className={styles.expressionCue}>真实 · 自由 · 不必完整</div>
             </div>
@@ -463,7 +498,7 @@ const EpisodeCardCreate: React.FC = () => {
           </Button>
         </div>
         <p className={styles.privacy}>
-          照片只在你的浏览器中处理，不会自动上传。
+          照片只在你的浏览器中处理；二维码会邀请朋友也来写一句。
         </p>
       </section>
     </main>

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -99,9 +99,7 @@ const EpisodeCardCreate: React.FC = () => {
         day: 'numeric',
       })
     : '';
-  const episodeTheme = episode?.theme || episode?.meetup.default_theme || '';
-
-  const displayText = text.trim() || '写下此刻值得留下的想法。';
+  const displayText = text.trim() || '写下此刻还留在心里的片段。';
   const displayAuthor = author.trim() || '匿名';
   const weightedLength =
     Array.from(displayText).length +
@@ -271,17 +269,10 @@ const EpisodeCardCreate: React.FC = () => {
           </Link>
           <span>约 2 分钟</span>
         </div>
-        <h1>写下一句，留在本期</h1>
+        <h1>刚才有什么留在你心里？</h1>
         <p className={styles.description}>
-          不必总结整场分享，只写此刻还留在你心里的话。
+          可以是一句话、一个碎片、一点启发，或者刚刚冒出的新想法。不必总结整场分享。
         </p>
-
-        {episodeTheme && (
-          <p className={styles.theme}>
-            <span>本期主题</span>
-            {episodeTheme}
-          </p>
-        )}
 
         {error && <Alert severity="warning">{error}</Alert>}
 
@@ -289,7 +280,7 @@ const EpisodeCardCreate: React.FC = () => {
           value={text}
           maxLength={MAX_TEXT_LENGTH}
           onChange={(event) => setText(event.target.value)}
-          placeholder="一句话、一段感受，或者一个接下来想做的行动……"
+          placeholder="哪句话触动了你？你想到了什么？或者接下来想试着做什么？"
           className={styles.textarea}
           disabled={Boolean(publishedResponseId)}
           autoFocus
@@ -413,7 +404,7 @@ const EpisodeCardCreate: React.FC = () => {
               checked={showEpisodeInfo}
               onChange={(_, value) => setShowEpisodeInfo(value)}
             />
-            显示本期主题、日期和期数
+            显示期数和日期
           </label>
         </div>
       </section>
@@ -453,10 +444,9 @@ const EpisodeCardCreate: React.FC = () => {
                     ? `启发星球 EP${episode.episode_number}`
                     : '启发星球'}
                 </div>
-                {showEpisodeInfo && (episodeTheme || episodeDate) && (
+                {showEpisodeInfo && episodeDate && (
                   <div className={styles.episodeDetails}>
-                    {episodeTheme && <strong>{episodeTheme}</strong>}
-                    {episodeDate && <span>{episodeDate}</span>}
+                    <span>{episodeDate}</span>
                   </div>
                 )}
               </div>

--- a/src/pages/card/EpisodeCardCreate/index.tsx
+++ b/src/pages/card/EpisodeCardCreate/index.tsx
@@ -6,12 +6,19 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Alert, Button, CircularProgress, Switch } from '@mui/material';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  Switch,
+} from '@mui/material';
 import html2canvas from 'html2canvas';
 import { QRCodeSVG } from 'qrcode.react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 
-import { episodesApi } from '@/netlify/config';
+import { episodeResponsesApi, episodesApi } from '@/netlify/config';
 import { EpisodeCardContext } from '@/netlify/functions/episodes';
 import { getUserName } from '@/utils';
 import { saveImageDataUrl } from '@/utils/share';
@@ -40,8 +47,14 @@ const EpisodeCardCreate: React.FC = () => {
   const [photo, setPhoto] = useState<string | null>(null);
   const [photoMode, setPhotoMode] = useState<PhotoMode>('cover');
   const [showEpisodeInfo, setShowEpisodeInfo] = useState(true);
+  const [publishConsent, setPublishConsent] = useState(false);
+  const [website, setWebsite] = useState('');
+  const [publishedResponseId, setPublishedResponseId] = useState<number | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -108,10 +121,7 @@ const EpisodeCardCreate: React.FC = () => {
       quote.style.lineHeight =
         weightedLength > 300 ? '1.32' : weightedLength > 180 ? '1.4' : '1.5';
 
-      while (
-        container.scrollHeight > container.clientHeight &&
-        fontSize > 10
-      ) {
+      while (container.scrollHeight > container.clientHeight && fontSize > 10) {
         fontSize -= 1;
         quote.style.fontSize = `${fontSize}px`;
       }
@@ -197,6 +207,32 @@ const EpisodeCardCreate: React.FC = () => {
     }
   };
 
+  const handlePublish = async () => {
+    if (!text.trim() || !publishConsent || publishedResponseId) return;
+
+    setIsPublishing(true);
+    setError(null);
+    try {
+      const response = await episodeResponsesApi.create({
+        meetup_id: meetupId,
+        episode_number: episodeNumber,
+        content: text,
+        author,
+        publish_consent: publishConsent,
+        website,
+      });
+
+      if (!response.success || !response.data?.response) {
+        throw new Error(response.error || '发布失败，请稍后再试');
+      }
+      setPublishedResponseId(response.data.response.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '发布失败，请稍后再试');
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className={styles.state}>
@@ -221,7 +257,7 @@ const EpisodeCardCreate: React.FC = () => {
         <p className={styles.eyebrow}>启发星球 EP{episode.episode_number}</p>
         <h1>你想记录下什么？</h1>
         <p className={styles.description}>
-          无论是现场参与、听完回放，还是后来想到的，都可以写下来。
+          不必完整。写下一句此刻还留在你心里的话，和本期星友彼此照亮。
         </p>
 
         {error && <Alert severity="warning">{error}</Alert>}
@@ -232,6 +268,7 @@ const EpisodeCardCreate: React.FC = () => {
           onChange={(event) => setText(event.target.value)}
           placeholder="一句话、一段感受，或者一个接下来想做的行动……"
           className={styles.textarea}
+          disabled={Boolean(publishedResponseId)}
           autoFocus
         />
         <div className={styles.counter}>
@@ -246,9 +283,71 @@ const EpisodeCardCreate: React.FC = () => {
             maxLength={MAX_AUTHOR_LENGTH}
             onChange={(event) => setAuthor(event.target.value)}
             placeholder="你的名字或昵称"
+            disabled={Boolean(publishedResponseId)}
           />
           <small>留空时显示“匿名”</small>
         </label>
+
+        <label className={styles.honeypot} aria-hidden="true">
+          请勿填写
+          <input
+            type="text"
+            value={website}
+            onChange={(event) => setWebsite(event.target.value)}
+            tabIndex={-1}
+            autoComplete="off"
+          />
+        </label>
+
+        <div className={styles.publishPanel}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={publishConsent}
+                onChange={(_, value) => setPublishConsent(value)}
+                disabled={Boolean(publishedResponseId)}
+              />
+            }
+            label="我愿意将这段文字和署名公开到本期回应墙"
+          />
+          <small>公开后，任何访问本期页面的人都可以看到。</small>
+          <Button
+            variant="contained"
+            size="large"
+            disabled={
+              !text.trim() ||
+              !publishConsent ||
+              isPublishing ||
+              Boolean(publishedResponseId)
+            }
+            onClick={handlePublish}
+          >
+            {isPublishing
+              ? '正在发布…'
+              : publishedResponseId
+                ? '已发布到回应墙'
+                : '发布到本期回应墙'}
+          </Button>
+          {publishedResponseId && (
+            <Alert severity="success">
+              你的回应已经出现在 EP{episode.episode_number} 回应墙。{' '}
+              <Link
+                to={`/episode/${meetupId}/${episodeNumber}#responses`}
+                className={styles.inlineLink}
+              >
+                去看看大家写了什么
+              </Link>
+            </Alert>
+          )}
+          {!publishedResponseId && (
+            <Link
+              to={`/episode/${meetupId}/${episodeNumber}#responses`}
+              className={styles.wallLink}
+            >
+              先看看本期回应墙
+            </Link>
+          )}
+        </div>
 
         <label className={styles.photoButton}>
           ＋ 添加一张照片（可选）
@@ -363,7 +462,9 @@ const EpisodeCardCreate: React.FC = () => {
             保存图片
           </Button>
         </div>
-        <p className={styles.privacy}>照片只在你的浏览器中处理，不会自动上传。</p>
+        <p className={styles.privacy}>
+          照片只在你的浏览器中处理，不会自动上传。
+        </p>
       </section>
     </main>
   );

--- a/src/pages/card/WeeklyCards.tsx
+++ b/src/pages/card/WeeklyCards.tsx
@@ -616,9 +616,9 @@ const WeeklyCards: React.FC = () => {
         qrContainer.style.border = `1px solid ${qrPanelStyles.borderColor}`;
         qrContainer.style.boxShadow = '0 10px 28px rgba(15, 23, 42, 0.12)';
 
-        const episodeStr = card?.episode ? card.episode.toLowerCase() : '';
-        const targetUrl = episodeStr
-          ? `${window.location.origin}/weekly-cards/${episodeStr}`
+        const episodeNumber = Number(card?.episode?.match(/\d+/)?.[0] || 0);
+        const targetUrl = episodeNumber
+          ? `${window.location.origin}/episode/39/${episodeNumber}`
           : window.location.href;
 
         await (window as any).QRCode.toCanvas(qrCanvas, targetUrl, {
@@ -712,6 +712,12 @@ const WeeklyCards: React.FC = () => {
         parseInt(a.replace(/\D/g, '') || '0')
     );
 
+  const activeEpisodeNumber = Number(
+    (episodeFromPath || (!showAll ? cards[0]?.episode : ''))?.match(
+      /\d+/
+    )?.[0] || 0
+  );
+
   return (
     <Box
       sx={{
@@ -726,6 +732,19 @@ const WeeklyCards: React.FC = () => {
           <h1>启发星球周刊</h1>
           <span>从每周真实的分享里，收藏一句话，也带走一个新的视角。</span>
         </header>
+
+        {activeEpisodeNumber > 0 && (
+          <nav className={styles.episodeJourney} aria-label="本期参与入口">
+            <span>EP{activeEpisodeNumber} 不只是一份周刊</span>
+            <Link to={`/episode/39/${activeEpisodeNumber}`}>看本期回应墙</Link>
+            <Link
+              to={`/create-card?meetupId=39&episode=${activeEpisodeNumber}`}
+              className={styles.episodeJourneyPrimary}
+            >
+              写下我的一句
+            </Link>
+          </nav>
+        )}
 
         <Paper
           elevation={0}

--- a/src/pages/card/WeeklyCards.tsx
+++ b/src/pages/card/WeeklyCards.tsx
@@ -618,7 +618,7 @@ const WeeklyCards: React.FC = () => {
 
         const episodeNumber = Number(card?.episode?.match(/\d+/)?.[0] || 0);
         const targetUrl = episodeNumber
-          ? `${window.location.origin}/episode/39/${episodeNumber}`
+          ? `${window.location.origin}/episodes/${episodeNumber}`
           : window.location.href;
 
         await (window as any).QRCode.toCanvas(qrCanvas, targetUrl, {
@@ -736,9 +736,9 @@ const WeeklyCards: React.FC = () => {
         {activeEpisodeNumber > 0 && (
           <nav className={styles.episodeJourney} aria-label="本期参与入口">
             <span>EP{activeEpisodeNumber} 不只是一份周刊</span>
-            <Link to={`/episode/39/${activeEpisodeNumber}`}>看本期回应墙</Link>
+            <Link to={`/episodes/${activeEpisodeNumber}`}>看本期回应墙</Link>
             <Link
-              to={`/create-card?meetupId=39&episode=${activeEpisodeNumber}`}
+              to={`/episodes/${activeEpisodeNumber}/respond`}
               className={styles.episodeJourneyPrimary}
             >
               写下我的一句

--- a/src/pages/card/weeklyCards.module.css
+++ b/src/pages/card/weeklyCards.module.css
@@ -33,3 +33,42 @@
     padding: 3rem 0.5rem 1.75rem;
   }
 }
+.episodeJourney {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  width: fit-content;
+  max-width: 100%;
+  margin: -24px auto 32px;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid #e8d9cd;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.88);
+  color: #75665d;
+  font-size: 0.88rem;
+}
+
+.episodeJourney a {
+  color: #a94e2b;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.episodeJourneyPrimary {
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: #a94e2b;
+  color: #fff !important;
+}
+
+@media (max-width: 600px) {
+  .episodeJourney {
+    width: 100%;
+    box-sizing: border-box;
+    flex-direction: column;
+    margin-top: -12px;
+    padding: 16px;
+    border-radius: 18px;
+  }
+}

--- a/src/pages/episode/EpisodeHub.tsx
+++ b/src/pages/episode/EpisodeHub.tsx
@@ -12,6 +12,8 @@ import { EpisodeResponse } from '@/netlify/functions/episodeResponses';
 import { WeeklyCard } from '@/netlify/services/weeklyCards';
 import styles from './episodeHub.module.css';
 
+const INSPIRE_PLANET_MEETUP_ID = 39;
+
 const getDetailPreview = (detail = '') =>
   detail
     .replace(/<[^>]*>/g, ' ')
@@ -22,8 +24,8 @@ const getDetailPreview = (detail = '') =>
     .trim();
 
 const EpisodeHub: React.FC = () => {
-  const params = useParams<{ meetupId: string; episode: string }>();
-  const meetupId = Number(params.meetupId);
+  const params = useParams<{ episode: string }>();
+  const meetupId = INSPIRE_PLANET_MEETUP_ID;
   const episodeNumber = Number(params.episode);
   const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
   const [responses, setResponses] = useState<EpisodeResponse[]>([]);
@@ -32,8 +34,8 @@ const EpisodeHub: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const createUrl = useMemo(
-    () => `/create-card?meetupId=${meetupId}&episode=${episodeNumber}`,
-    [meetupId, episodeNumber]
+    () => `/episodes/${episodeNumber}/respond`,
+    [episodeNumber]
   );
 
   useEffect(() => {

--- a/src/pages/episode/EpisodeHub.tsx
+++ b/src/pages/episode/EpisodeHub.tsx
@@ -23,6 +23,13 @@ const getDetailPreview = (detail = '') =>
     .replace(/\s+/g, ' ')
     .trim();
 
+const formatEpisodeDate = (date: string) =>
+  new Date(`${date}T00:00:00`).toLocaleDateString('zh-CN', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
 const EpisodeHub: React.FC = () => {
   const params = useParams<{ episode: string }>();
   const meetupId = INSPIRE_PLANET_MEETUP_ID;
@@ -102,16 +109,16 @@ const EpisodeHub: React.FC = () => {
     );
   }
 
-  const theme = episode.theme || episode.meetup.default_theme || '';
-
   return (
     <main className={styles.page}>
       <header className={styles.hero}>
-        <p className={styles.eyebrow}>启发星球 · EP{episode.episode_number}</p>
-        <h1>{theme || episode.meetup.title}</h1>
-        {episode.date && <time dateTime={episode.date}>{episode.date}</time>}
+        <p className={styles.eyebrow}>每周线上分享</p>
+        <h1>启发星球 EP{episode.episode_number}</h1>
+        {episode.date && (
+          <time dateTime={episode.date}>{formatEpisodeDate(episode.date)}</time>
+        )}
         <p className={styles.intro}>
-          一场分享结束了，但一些话还在继续生长。这里收集本期周刊与星友们现场写下的回应。
+          大家从过去一周带来各自的碎片输入、启发与思考。这里收集本期周刊，以及分享结束后仍想留下的话。
         </p>
         <div className={styles.heroActions}>
           <Link to={createUrl} className={styles.primaryAction}>
@@ -127,7 +134,7 @@ const EpisodeHub: React.FC = () => {
         <div className={styles.sectionHeading}>
           <div>
             <p>本期周刊</p>
-            <h2 id="weekly-heading">从分享里带走的视角</h2>
+            <h2 id="weekly-heading">这一期，我们分享了什么</h2>
           </div>
           {weeklyCards.length > 0 && (
             <Link to={`/weekly-cards/${episodeNumber}`}>阅读完整周刊</Link>
@@ -161,7 +168,7 @@ const EpisodeHub: React.FC = () => {
         <div className={styles.sectionHeading}>
           <div>
             <p>本期回应墙 · {responses.length} 条</p>
-            <h2 id="responses-heading">此刻还留在大家心里的话</h2>
+            <h2 id="responses-heading">从这些片段继续生长</h2>
           </div>
           <Link to={createUrl}>我也写一句</Link>
         </div>
@@ -190,7 +197,7 @@ const EpisodeHub: React.FC = () => {
           <div className={styles.emptyWall}>
             <span>✦</span>
             <h3>这里正等着第一句话</h3>
-            <p>不必总结整场分享，只写下此刻最想留下的一句。</p>
+            <p>可以是一句话、一个片段，或刚刚冒出的新想法。</p>
             <Link to={createUrl} className={styles.primaryAction}>
               成为第一个回应的人
             </Link>

--- a/src/pages/episode/EpisodeHub.tsx
+++ b/src/pages/episode/EpisodeHub.tsx
@@ -184,7 +184,9 @@ const EpisodeHub: React.FC = () => {
                 <footer>
                   <strong>{response.author}</strong>
                   <time dateTime={response.created_at}>
+                    回应于{' '}
                     {new Date(response.created_at).toLocaleDateString('zh-CN', {
+                      year: 'numeric',
                       month: 'long',
                       day: 'numeric',
                     })}

--- a/src/pages/episode/EpisodeHub.tsx
+++ b/src/pages/episode/EpisodeHub.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, CircularProgress } from '@mui/material';
+import { Link, useParams } from 'react-router-dom';
+
+import {
+  episodeResponsesApi,
+  episodesApi,
+  weeklyCardsApi,
+} from '@/netlify/config';
+import { EpisodeCardContext } from '@/netlify/functions/episodes';
+import { EpisodeResponse } from '@/netlify/functions/episodeResponses';
+import { WeeklyCard } from '@/netlify/services/weeklyCards';
+import styles from './episodeHub.module.css';
+
+const getDetailPreview = (detail = '') =>
+  detail
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[#>*_`~\-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const EpisodeHub: React.FC = () => {
+  const params = useParams<{ meetupId: string; episode: string }>();
+  const meetupId = Number(params.meetupId);
+  const episodeNumber = Number(params.episode);
+  const [episode, setEpisode] = useState<EpisodeCardContext | null>(null);
+  const [responses, setResponses] = useState<EpisodeResponse[]>([]);
+  const [weeklyCards, setWeeklyCards] = useState<WeeklyCard[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const createUrl = useMemo(
+    () => `/create-card?meetupId=${meetupId}&episode=${episodeNumber}`,
+    [meetupId, episodeNumber]
+  );
+
+  useEffect(() => {
+    const loadEpisodeHub = async () => {
+      if (!Number.isInteger(meetupId) || !Number.isInteger(episodeNumber)) {
+        setError('缺少有效的活动或期数信息');
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const [episodeResult, responsesResult, weeklyResult] =
+          await Promise.all([
+            episodesApi.getByMeetupEpisode(meetupId, episodeNumber),
+            episodeResponsesApi.getByEpisode(meetupId, episodeNumber),
+            weeklyCardsApi.getByEpisode(String(episodeNumber)),
+          ]);
+
+        if (!episodeResult.success || !episodeResult.data?.episode) {
+          throw new Error(episodeResult.error || '无法读取本期活动');
+        }
+
+        setEpisode(episodeResult.data.episode);
+        if (responsesResult.success) {
+          setResponses(responsesResult.data?.responses || []);
+        }
+        if (weeklyResult.success) {
+          setWeeklyCards(weeklyResult.data?.records || []);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '无法读取本期内容');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadEpisodeHub();
+  }, [meetupId, episodeNumber]);
+
+  useEffect(() => {
+    if (!isLoading && window.location.hash === '#responses') {
+      window.requestAnimationFrame(() => {
+        document.getElementById('responses')?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      });
+    }
+  }, [isLoading]);
+
+  if (isLoading) {
+    return (
+      <main className={styles.state}>
+        <CircularProgress />
+      </main>
+    );
+  }
+
+  if (error || !episode) {
+    return (
+      <main className={styles.state}>
+        <Alert severity="error">{error || '本期内容不存在'}</Alert>
+      </main>
+    );
+  }
+
+  const theme = episode.theme || episode.meetup.default_theme || '';
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.hero}>
+        <p className={styles.eyebrow}>启发星球 · EP{episode.episode_number}</p>
+        <h1>{theme || episode.meetup.title}</h1>
+        {episode.date && <time dateTime={episode.date}>{episode.date}</time>}
+        <p className={styles.intro}>
+          一场分享结束了，但一些话还在继续生长。这里收集本期周刊与星友们现场写下的回应。
+        </p>
+        <div className={styles.heroActions}>
+          <Link to={createUrl} className={styles.primaryAction}>
+            写下我的一句
+          </Link>
+          <a href="#responses" className={styles.secondaryAction}>
+            看看大家的回应
+          </a>
+        </div>
+      </header>
+
+      <section className={styles.section} aria-labelledby="weekly-heading">
+        <div className={styles.sectionHeading}>
+          <div>
+            <p>本期周刊</p>
+            <h2 id="weekly-heading">从分享里带走的视角</h2>
+          </div>
+          {weeklyCards.length > 0 && (
+            <Link to={`/weekly-cards/${episodeNumber}`}>阅读完整周刊</Link>
+          )}
+        </div>
+
+        {weeklyCards.length > 0 ? (
+          <div className={styles.weeklyGrid}>
+            {weeklyCards.slice(0, 3).map((card) => (
+              <article className={styles.weeklyCard} key={card.id}>
+                <span>分享者 · {card.name}</span>
+                <h3>{card.title}</h3>
+                <blockquote>{card.quote}</blockquote>
+                {card.detail && <p>{getDetailPreview(card.detail)}</p>}
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className={styles.pendingCard}>
+            <strong>本期周刊正在整理中</strong>
+            <p>你可以先写下自己的那一句。周刊发布后，会自动出现在这里。</p>
+          </div>
+        )}
+      </section>
+
+      <section
+        className={`${styles.section} ${styles.responsesSection}`}
+        id="responses"
+        aria-labelledby="responses-heading"
+      >
+        <div className={styles.sectionHeading}>
+          <div>
+            <p>本期回应墙 · {responses.length} 条</p>
+            <h2 id="responses-heading">此刻还留在大家心里的话</h2>
+          </div>
+          <Link to={createUrl}>我也写一句</Link>
+        </div>
+
+        {responses.length > 0 ? (
+          <div className={styles.responseGrid}>
+            {responses.map((response, index) => (
+              <article className={styles.responseCard} key={response.id}>
+                <span className={styles.responseNumber}>
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <blockquote>{response.content}</blockquote>
+                <footer>
+                  <strong>{response.author}</strong>
+                  <time dateTime={response.created_at}>
+                    {new Date(response.created_at).toLocaleDateString('zh-CN', {
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </time>
+                </footer>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className={styles.emptyWall}>
+            <span>✦</span>
+            <h3>这里正等着第一句话</h3>
+            <p>不必总结整场分享，只写下此刻最想留下的一句。</p>
+            <Link to={createUrl} className={styles.primaryAction}>
+              成为第一个回应的人
+            </Link>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default EpisodeHub;

--- a/src/pages/episode/episodeHub.module.css
+++ b/src/pages/episode/episodeHub.module.css
@@ -1,0 +1,318 @@
+.page {
+  min-height: 100vh;
+  padding-bottom: 80px;
+  color: #3c332e;
+  background: #fffaf5;
+}
+
+.hero {
+  display: flex;
+  min-height: 430px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 72px 20px 64px;
+  text-align: center;
+  background:
+    radial-gradient(
+      circle at 18% 12%,
+      rgba(255, 255, 255, 0.9),
+      transparent 30%
+    ),
+    linear-gradient(145deg, #fff4dc, #f6c9ae 56%, #e69472);
+}
+
+.eyebrow,
+.sectionHeading p {
+  margin: 0 0 10px;
+  color: #a94e2b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.hero h1 {
+  max-width: 820px;
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(2.3rem, 6vw, 4.8rem);
+  font-weight: 600;
+  line-height: 1.15;
+  text-wrap: balance;
+}
+
+.hero time {
+  margin-top: 16px;
+  color: rgba(60, 51, 46, 0.66);
+}
+
+.intro {
+  max-width: 620px;
+  margin: 24px auto 0;
+  color: #6f5d53;
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.heroActions {
+  display: flex;
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.primaryAction,
+.secondaryAction {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 20px;
+  border-radius: 999px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.primaryAction {
+  background: #a94e2b;
+  color: #fff;
+  box-shadow: 0 10px 28px rgba(106, 53, 31, 0.2);
+}
+
+.secondaryAction {
+  border: 1px solid rgba(91, 58, 42, 0.28);
+  color: #633e2c;
+}
+
+.section {
+  width: min(1120px, calc(100% - 40px));
+  margin: 72px auto 0;
+}
+
+.sectionHeading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.sectionHeading h2 {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(1.7rem, 3vw, 2.5rem);
+  font-weight: 600;
+}
+
+.sectionHeading > a {
+  flex-shrink: 0;
+  color: #a94e2b;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.weeklyGrid,
+.responseGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.weeklyCard,
+.responseCard,
+.pendingCard,
+.emptyWall {
+  border: 1px solid #eadfd4;
+  border-radius: 20px;
+  background: #fff;
+}
+
+.weeklyCard {
+  min-height: 270px;
+  padding: 24px;
+}
+
+.weeklyCard > span {
+  color: #a94e2b;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.weeklyCard h3 {
+  margin: 16px 0 14px;
+  font-family: var(--font-serif);
+  font-size: 1.35rem;
+}
+
+.weeklyCard blockquote,
+.responseCard blockquote {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+
+.weeklyCard blockquote {
+  padding-left: 14px;
+  border-left: 3px solid #efb08f;
+  color: #5b4a40;
+  font-weight: 650;
+  line-height: 1.7;
+}
+
+.weeklyCard > p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 18px 0 0;
+  color: #84766d;
+  font-size: 0.88rem;
+  line-height: 1.65;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.pendingCard {
+  padding: 32px;
+  text-align: center;
+}
+
+.pendingCard strong {
+  font-family: var(--font-serif);
+  font-size: 1.35rem;
+}
+
+.pendingCard p {
+  margin: 10px 0 0;
+  color: #84766d;
+}
+
+.responsesSection {
+  scroll-margin-top: 80px;
+}
+
+.responseGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.responseCard {
+  position: relative;
+  display: flex;
+  min-height: 220px;
+  flex-direction: column;
+  padding: 28px;
+  overflow: hidden;
+}
+
+.responseCard:nth-child(4n + 1) {
+  background: #fff4dc;
+}
+
+.responseCard:nth-child(4n + 2) {
+  background: #fce9de;
+}
+
+.responseCard:nth-child(4n + 3) {
+  background: #f4eee7;
+}
+
+.responseNumber {
+  color: rgba(169, 78, 43, 0.58);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.responseCard blockquote {
+  margin: auto 0;
+  padding: 22px 0;
+  font-family: var(--font-serif);
+  font-size: clamp(1.25rem, 2.4vw, 1.75rem);
+  font-weight: 600;
+  line-height: 1.55;
+}
+
+.responseCard footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #83736a;
+  font-size: 0.8rem;
+}
+
+.responseCard footer strong {
+  color: #5b4438;
+}
+
+.emptyWall {
+  display: flex;
+  min-height: 300px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  text-align: center;
+}
+
+.emptyWall > span {
+  color: #d86f42;
+  font-size: 2rem;
+}
+
+.emptyWall h3 {
+  margin: 10px 0 0;
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+}
+
+.emptyWall p {
+  margin: 10px 0 22px;
+  color: #84766d;
+}
+
+.state {
+  display: grid;
+  min-height: 70vh;
+  place-items: center;
+  padding: 24px;
+  background: #fffaf5;
+}
+
+@media (max-width: 760px) {
+  .hero {
+    min-height: 0;
+    padding: 52px 18px 46px;
+  }
+
+  .heroActions,
+  .sectionHeading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .heroActions {
+    width: 100%;
+    max-width: 360px;
+  }
+
+  .section {
+    width: min(100% - 28px, 1120px);
+    margin-top: 52px;
+  }
+
+  .sectionHeading {
+    gap: 12px;
+  }
+
+  .sectionHeading > a {
+    align-self: flex-start;
+  }
+
+  .weeklyGrid,
+  .responseGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .weeklyCard,
+  .responseCard {
+    min-height: 0;
+  }
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -53,6 +53,9 @@ const getDetailPreview = (detail = '') =>
     .replace(/\s+/g, ' ')
     .trim();
 
+const getEpisodeNumberFromLabel = (episode = '') =>
+  Number(episode.match(/\d+/)?.[0] || 0);
+
 const Home: React.FC = () => {
   const [cards, setCards] = useState<WeeklyCard[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -166,8 +169,11 @@ const Home: React.FC = () => {
               </p>
             )}
             <div className={styles['weekly-author']}>分享者 · {card.name}</div>
-            <Link to="/weekly-cards" className={styles['weekly-link']}>
-              阅读这期周刊 <ChevronRight fontSize="inherit" />
+            <Link
+              to={`/episode/39/${getEpisodeNumberFromLabel(card.episode)}`}
+              className={styles['weekly-link']}
+            >
+              进入本期页面 <ChevronRight fontSize="inherit" />
             </Link>
           </article>
         ))}
@@ -175,13 +181,20 @@ const Home: React.FC = () => {
     );
   };
 
+  const latestEpisodeNumber = getEpisodeNumberFromLabel(cards[0]?.episode);
+  const latestCreateUrl = latestEpisodeNumber
+    ? `/create-card?meetupId=39&episode=${latestEpisodeNumber}`
+    : '/weekly-cards';
+
   const entryPoints: EntryPoint[] = [
     {
-      eyebrow: '创作',
-      title: '创建卡片',
-      description: '记录一句触动你的话，让当下的启发留下来。',
-      label: '开始创建卡片',
-      to: '/create-card',
+      eyebrow: '回应',
+      title: '写下本期一句',
+      description: '分享结束后，留下此刻还在你心里的一句话。',
+      label: latestEpisodeNumber
+        ? `回应 EP${latestEpisodeNumber}`
+        : '看看本期内容',
+      to: latestCreateUrl,
     },
     {
       eyebrow: '相遇',
@@ -332,15 +345,19 @@ const Home: React.FC = () => {
             {renderWeeklyCards()}
           </div>
           <div className={styles['view-all-container']}>
-            <Link
-              to="/weekly-cards"
-              className={styles['view-all-button']}
-            >
+            {latestEpisodeNumber > 0 && (
+              <Link
+                to={`/episode/39/${latestEpisodeNumber}`}
+                className={styles['view-all-button']}
+              >
+                进入本期页面 <ChevronRight fontSize="inherit" />
+              </Link>
+            )}
+            <Link to="/weekly-cards" className={styles['view-all-button']}>
               查看全部往期周刊 <ChevronRight fontSize="inherit" />
             </Link>
           </div>
         </section>
-
       </Container>
 
       <aside

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -170,7 +170,7 @@ const Home: React.FC = () => {
             )}
             <div className={styles['weekly-author']}>分享者 · {card.name}</div>
             <Link
-              to={`/episode/39/${getEpisodeNumberFromLabel(card.episode)}`}
+              to={`/episodes/${getEpisodeNumberFromLabel(card.episode)}`}
               className={styles['weekly-link']}
             >
               进入本期页面 <ChevronRight fontSize="inherit" />
@@ -183,7 +183,7 @@ const Home: React.FC = () => {
 
   const latestEpisodeNumber = getEpisodeNumberFromLabel(cards[0]?.episode);
   const latestCreateUrl = latestEpisodeNumber
-    ? `/create-card?meetupId=39&episode=${latestEpisodeNumber}`
+    ? `/episodes/${latestEpisodeNumber}/respond`
     : '/weekly-cards';
 
   const entryPoints: EntryPoint[] = [
@@ -347,7 +347,7 @@ const Home: React.FC = () => {
           <div className={styles['view-all-container']}>
             {latestEpisodeNumber > 0 && (
               <Link
-                to={`/episode/39/${latestEpisodeNumber}`}
+                to={`/episodes/${latestEpisodeNumber}`}
                 className={styles['view-all-button']}
               >
                 进入本期页面 <ChevronRight fontSize="inherit" />

--- a/src/pages/home/home.module.css
+++ b/src/pages/home/home.module.css
@@ -394,6 +394,8 @@
   margin-top: 1.75rem;
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
+  gap: 1.25rem;
 }
 
 .view-all-button {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,10 @@
 import React, { Suspense, lazy, useState, useEffect } from 'react';
-import { createBrowserRouter, Navigate, useLocation } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  Navigate,
+  useLocation,
+  useSearchParams,
+} from 'react-router-dom';
 
 // 导入主组件和工具组件
 import App from '../App';
@@ -152,6 +157,16 @@ const WritingCircle = lazy(() => import('../pages/writing/WritingCircle'));
 const WritingEditor = lazy(() => import('../pages/writing/WritingEditor'));
 const WritingDetail = lazy(() => import('../pages/writing/WritingDetail'));
 const WritingAdmin = lazy(() => import('../pages/writing/WritingAdmin'));
+const EpisodeHub = lazy(() => import('../pages/episode/EpisodeHub'));
+
+const CardCreateRoute: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const hasEpisodeContext =
+    searchParams.has('episode') || searchParams.has('episodeId');
+  const page = createLazyRoute(<CreateCard />);
+
+  return hasEpisodeContext ? page : <ProtectedRoute>{page}</ProtectedRoute>;
+};
 
 // 创建路由器
 const router = createBrowserRouter(
@@ -206,6 +221,10 @@ const router = createBrowserRouter(
           path: 'weekly-cards/:episode',
           element: createLazyRoute(<WeeklyCards />),
         },
+        {
+          path: 'episode/:meetupId/:episode',
+          element: createLazyRoute(<EpisodeHub />),
+        },
         { path: 'card-detail', element: createLazyRoute(<CardDetail />) },
         {
           path: 'meetup-detail',
@@ -223,8 +242,9 @@ const router = createBrowserRouter(
         { path: 'act-signup', element: createLazyRoute(<ActSignup />) },
         { path: '404', element: createLazyRoute(<NotFound />) },
 
+        // 专属期次入口公开；通用卡片创建仍需登录
+        { path: 'create-card', element: <CardCreateRoute /> },
         // 受保护路由
-        { path: 'create-card', element: createProtectedRoute(<CreateCard />) },
         { path: 'my-cards', element: createProtectedRoute(<MyCards />) },
         { path: 'card-edit/:id', element: createProtectedRoute(<CardEdit />) },
         {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import {
   createBrowserRouter,
   Navigate,
   useLocation,
+  useParams,
   useSearchParams,
 } from 'react-router-dom';
 
@@ -158,14 +159,29 @@ const WritingEditor = lazy(() => import('../pages/writing/WritingEditor'));
 const WritingDetail = lazy(() => import('../pages/writing/WritingDetail'));
 const WritingAdmin = lazy(() => import('../pages/writing/WritingAdmin'));
 const EpisodeHub = lazy(() => import('../pages/episode/EpisodeHub'));
+const EpisodeCardCreate = lazy(() => import('../pages/card/EpisodeCardCreate'));
 
 const CardCreateRoute: React.FC = () => {
   const [searchParams] = useSearchParams();
-  const hasEpisodeContext =
-    searchParams.has('episode') || searchParams.has('episodeId');
+  const episode = searchParams.get('episode') || searchParams.get('episodeId');
   const page = createLazyRoute(<CreateCard />);
 
-  return hasEpisodeContext ? page : <ProtectedRoute>{page}</ProtectedRoute>;
+  if (episode) {
+    return <Navigate to={`/episodes/${episode}/respond`} replace />;
+  }
+
+  return <ProtectedRoute>{page}</ProtectedRoute>;
+};
+
+const LegacyEpisodeRoute: React.FC = () => {
+  const { episode } = useParams<{ episode: string }>();
+  const location = useLocation();
+
+  return episode ? (
+    <Navigate to={`/episodes/${episode}${location.hash}`} replace />
+  ) : (
+    <Navigate to="/404" replace />
+  );
 };
 
 // 创建路由器
@@ -222,8 +238,16 @@ const router = createBrowserRouter(
           element: createLazyRoute(<WeeklyCards />),
         },
         {
-          path: 'episode/:meetupId/:episode',
+          path: 'episodes/:episode',
           element: createLazyRoute(<EpisodeHub />),
+        },
+        {
+          path: 'episodes/:episode/respond',
+          element: createLazyRoute(<EpisodeCardCreate />),
+        },
+        {
+          path: 'episode/:meetupId/:episode',
+          element: <LegacyEpisodeRoute />,
         },
         { path: 'card-detail', element: createLazyRoute(<CardDetail />) },
         {

--- a/supabase/migrations/20260805222451_create_episode_responses.sql
+++ b/supabase/migrations/20260805222451_create_episode_responses.sql
@@ -1,0 +1,38 @@
+create table if not exists public.episode_responses (
+  id bigint generated always as identity primary key,
+  meetup_id bigint not null references public.meetups(id) on delete cascade,
+  episode_number integer not null,
+  content text not null,
+  author text not null default '匿名',
+  status text not null default 'published',
+  request_fingerprint text,
+  created_at timestamptz not null default now(),
+  constraint episode_responses_episode_number_positive
+    check (episode_number > 0),
+  constraint episode_responses_content_length
+    check (char_length(btrim(content)) between 1 and 500),
+  constraint episode_responses_author_length
+    check (char_length(btrim(author)) between 1 and 24),
+  constraint episode_responses_status_valid
+    check (status in ('published', 'hidden'))
+);
+
+create index if not exists episode_responses_wall_idx
+  on public.episode_responses
+  (meetup_id, episode_number, status, created_at, id);
+
+create index if not exists episode_responses_rate_limit_idx
+  on public.episode_responses
+  (request_fingerprint, created_at)
+  where request_fingerprint is not null;
+
+alter table public.episode_responses enable row level security;
+
+revoke all on table public.episode_responses from anon, authenticated;
+revoke all on sequence public.episode_responses_id_seq from anon, authenticated;
+
+comment on table public.episode_responses is
+  'Public, opt-in responses submitted after an Inspire Planet episode.';
+
+comment on column public.episode_responses.request_fingerprint is
+  'One-way hash used only for short-window abuse prevention.';


### PR DESCRIPTION
## What changed

- add canonical public routes: `/episodes/:episode` for the episode hub and `/episodes/:episode/respond` for writing a response
- redirect the previous `/episode/:meetupId/:episode` and episode-specific `/create-card?...` links so shared links keep working
- make the response flow public while keeping the generic card creator behind login
- add explicit opt-in publishing to the episode response wall
- bring the weekly digest, participant responses, and “write one sentence” action into one episode journey
- redesign the response page into a tighter two-minute flow with a compact editor, sticky preview, and grouped optional settings
- make the public experience work without a fixed episode theme: the stable identity is episode number + date, and the prompt welcomes a sentence, fragment, inspiration, or new thought
- show the episode number and date on generated cards by default, with one control to hide them
- connect homepage, weekly digest, exported QR codes, and episode pages to the canonical routes
- add server-side validation, a honeypot, hashed short-window rate limiting, and a private Supabase table accessed only by the backend

## Why

Inspire Planet sessions do not usually have one fixed theme. People bring fragments, inputs, inspirations, and thoughts from the past week, so forcing a shared title misrepresents the gathering. The weekly digest and reflection-card tool were also separate destinations, and the original public paths exposed internal database details.

This creates one understandable loop:

1. open `/episodes/30/respond` during the meeting’s final two minutes
2. write and optionally publish one response
3. generate or share the card
4. see the response and weekly digest together at `/episodes/30`

## User impact

Participants can respond without creating an account, decide explicitly whether their text and name are public, generate or share a card, and see other responses from the same episode. They no longer need a session theme to understand the page or start writing. Photos remain browser-only and are never published to the wall.

## Validation

- 4 validation tests pass
- TypeScript typecheck passes
- production build passes
- formatting and whitespace checks pass
- canonical episode and response routes verified
- legacy episode and card URLs verified to redirect to the canonical routes, including the `#responses` anchor
- editor input, public-consent state, live card preview, and enabled actions verified without posting a test response
- Supabase migration is applied and verified
- RLS is enabled; `anon` and `authenticated` have no direct table access; `service_role` retains backend access