### PR TITLE
Store card images in GitHub assets

### DIFF
--- a/src/netlify/functions/cards.ts
+++ b/src/netlify/functions/cards.ts
@@ -9,6 +9,7 @@ import {
   getFunctionNameFromEvent,
   getDataFromEvent,
 } from '../utils/server';
+import { isPersistableCardImageUrl } from '../validation/cardImages';
 
 // 内存缓存
 interface Cache {
@@ -91,6 +92,9 @@ async function handleCreate(event: NetlifyEvent): Promise<NetlifyResponse> {
 
     if (!cardData.title || !cardData.quote || !cardData.detail) {
       return createErrorResponse('缺少必填字段');
+    }
+    if (!isPersistableCardImageUrl(cardData.upload)) {
+      return createErrorResponse('本地图片必须先上传到图片仓库');
     }
 
     const record = {
@@ -313,6 +317,13 @@ async function handleUpdate(event: NetlifyEvent): Promise<NetlifyResponse> {
 
     if (String(currentUserId) !== String(existingCard.user_id)) {
       return createErrorResponse('没有权限修改此卡片', 403);
+    }
+
+    if (
+      cardData.upload !== existingCard.upload &&
+      !isPersistableCardImageUrl(cardData.upload)
+    ) {
+      return createErrorResponse('本地图片必须先上传到图片仓库');
     }
 
     const updateData = {

--- a/src/netlify/functions/uploadImage.ts
+++ b/src/netlify/functions/uploadImage.ts
@@ -10,7 +10,7 @@ import {
 
 export interface ImageUploadRequest {
   base64Image: string;
-  purpose?: 'writing' | 'general';
+  purpose?: 'writing' | 'card' | 'general';
 }
 
 export interface ImageUploadResponse {
@@ -95,7 +95,12 @@ async function handleUpload(event: NetlifyEvent): Promise<NetlifyResponse> {
     const timestamp: number = Date.now();
     const randomString: string = Math.random().toString(36).substring(2, 8);
     const extension = imageType === 'jpeg' ? 'jpg' : imageType;
-    const folder = requestBody.purpose === 'writing' ? 'writing' : 'general';
+    const folder =
+      requestBody.purpose === 'writing'
+        ? 'writing'
+        : requestBody.purpose === 'card'
+          ? 'card'
+          : 'general';
     const filename: string = `user_uploads/${folder}/user_${currentUser.id}_${timestamp}_${randomString}.${extension}`;
 
     const url: string = `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/contents/${filename}`;

--- a/src/netlify/services/images.ts
+++ b/src/netlify/services/images.ts
@@ -5,7 +5,7 @@ import { http } from '../config/http';
 export const imagesApi = {
   upload: async (
     base64Image: string,
-    purpose: 'writing' | 'general' = 'general'
+    purpose: 'writing' | 'card' | 'general' = 'general'
   ): Promise<ApiResponse<{ url: string }>> => {
     return http.post<{ url: string }>('/uploadImage', 'upload', {
       base64Image,

--- a/src/netlify/validation/cardImages.test.ts
+++ b/src/netlify/validation/cardImages.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isPersistableCardImageUrl } from './cardImages';
+
+describe('isPersistableCardImageUrl', () => {
+  it('accepts an empty image or an HTTPS asset URL', () => {
+    expect(isPersistableCardImageUrl('')).toBe(true);
+    expect(
+      isPersistableCardImageUrl(
+        'https://raw.githubusercontent.com/sunling/inspireplanet-assets/main/user_uploads/card/card.png'
+      )
+    ).toBe(true);
+  });
+
+  it('rejects base64 and non-HTTPS values', () => {
+    expect(isPersistableCardImageUrl('data:image/png;base64,ZmFrZQ==')).toBe(
+      false
+    );
+    expect(isPersistableCardImageUrl('http://example.com/card.png')).toBe(
+      false
+    );
+    expect(isPersistableCardImageUrl('not-a-url')).toBe(false);
+  });
+});

--- a/src/netlify/validation/cardImages.ts
+++ b/src/netlify/validation/cardImages.ts
@@ -1,0 +1,9 @@
+export function isPersistableCardImageUrl(value?: string | null): boolean {
+  if (!value) return true;
+
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/src/pages/card/CardCreate/index.tsx
+++ b/src/pages/card/CardCreate/index.tsx
@@ -3,13 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import html2canvas from 'html2canvas';
 
 import { CardItem } from '../../../netlify/types';
-import { cardsApi } from '../../../netlify/config';
+import { cardsApi, imagesApi } from '../../../netlify/config';
 import { useGlobalSnackbar } from '@/context/app';
 import { getUserId } from '@/utils/user';
 import { gradientOptions } from '@/constants/gradient';
 import EditForm, { EditFormRef } from '../components/EditForm';
 import { getUserName } from '../../../utils';
 import { isMobileBrowser, saveImageDataUrl } from '@/utils/share';
+import { uploadCardImage } from '../uploadCardImage';
 
 const StandardCardCreate: React.FC = () => {
   const navigate = useNavigate();
@@ -42,10 +43,15 @@ const StandardCardCreate: React.FC = () => {
     cardData: CardItem,
     imageData?: { customImage?: string; selectedSearchImage?: string }
   ) => {
+    const uploadedImageUrl = await uploadCardImage(
+      imageData?.customImage,
+      Boolean(cardData.is_private),
+      imagesApi.upload
+    );
     const cardToSubmit = {
       ...cardData,
       created: new Date().toISOString(),
-      upload: imageData?.customImage,
+      upload: uploadedImageUrl,
       image_path: imageData?.selectedSearchImage,
       user_id: getUserId(),
     };

--- a/src/pages/card/components/EditForm.tsx
+++ b/src/pages/card/components/EditForm.tsx
@@ -150,13 +150,17 @@ const EditForm = forwardRef<EditFormRef, EditFormProps>(
         showSnackbar.error('请上传有效的图片文件');
         return;
       }
+      if (file.size > 4 * 1024 * 1024) {
+        showSnackbar.error('图片请控制在 4MB 以内');
+        return;
+      }
 
       const reader = new FileReader();
       reader.onload = (e) => {
         const result = e.target?.result as string;
         setCustomImage(result);
         setSelectedSearchImage('');
-        setFileStatus(`已上传: ${file.name}`);
+        setFileStatus(`已选择: ${file.name}`);
       };
       reader.onerror = () => {
         showSnackbar.error('图片读取失败');
@@ -281,7 +285,9 @@ const EditForm = forwardRef<EditFormRef, EditFormProps>(
           selectedSearchImage,
         });
       } catch (error) {
-        showSnackbar.error('提交失败，请稍后重试');
+        showSnackbar.error(
+          error instanceof Error ? error.message : '提交失败，请稍后重试'
+        );
       } finally {
         setIsSubmitting(false);
       }
@@ -592,6 +598,15 @@ const EditForm = forwardRef<EditFormRef, EditFormProps>(
                       {fileStatus && (
                         <Typography variant="caption" color="text.secondary">
                           {fileStatus}
+                        </Typography>
+                      )}
+                      {cardData.is_private && customImage && (
+                        <Typography
+                          variant="caption"
+                          color="warning.main"
+                          sx={{ display: 'block', mt: 0.5 }}
+                        >
+                          私密卡片暂不支持本地图片，因为图片仓库是公开的
                         </Typography>
                       )}
                     </FormControl>

--- a/src/pages/card/uploadCardImage.test.ts
+++ b/src/pages/card/uploadCardImage.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { uploadCardImage } from './uploadCardImage';
+
+describe('uploadCardImage', () => {
+  it('skips the upload when no local image was selected', async () => {
+    const uploader = vi.fn();
+
+    await expect(uploadCardImage(undefined, false, uploader)).resolves.toBe('');
+    expect(uploader).not.toHaveBeenCalled();
+  });
+
+  it('uploads card images to the card folder and returns the GitHub URL', async () => {
+    const uploader = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        url: 'https://raw.githubusercontent.com/sunling/inspireplanet-assets/main/user_uploads/card/card.png',
+      },
+    });
+
+    await expect(
+      uploadCardImage('data:image/png;base64,ZmFrZQ==', false, uploader)
+    ).resolves.toContain('sunling/inspireplanet-assets');
+    expect(uploader).toHaveBeenCalledWith(
+      'data:image/png;base64,ZmFrZQ==',
+      'card'
+    );
+  });
+
+  it('prevents card creation when the image upload fails', async () => {
+    const uploader = vi.fn().mockResolvedValue({
+      success: false,
+      error: 'GitHub upload failed',
+    });
+
+    await expect(
+      uploadCardImage('data:image/png;base64,ZmFrZQ==', false, uploader)
+    ).rejects.toThrow('GitHub upload failed');
+  });
+
+  it('rejects a successful response without an image URL', async () => {
+    const uploader = vi.fn().mockResolvedValue({ success: true, data: {} });
+
+    await expect(
+      uploadCardImage('data:image/png;base64,ZmFrZQ==', false, uploader)
+    ).rejects.toThrow('图片上传失败，请稍后重试');
+  });
+
+  it('does not publish a private card image to the public asset repo', async () => {
+    const uploader = vi.fn();
+
+    await expect(
+      uploadCardImage('data:image/png;base64,ZmFrZQ==', true, uploader)
+    ).rejects.toThrow('图片仓库是公开的');
+    expect(uploader).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/card/uploadCardImage.ts
+++ b/src/pages/card/uploadCardImage.ts
@@ -1,0 +1,29 @@
+export type CardImageUploader = (
+  base64Image: string,
+  purpose: 'card'
+) => Promise<{
+  success: boolean;
+  data?: { url?: string };
+  error?: string;
+}>;
+
+export async function uploadCardImage(
+  base64Image?: string,
+  isPrivate = false,
+  uploader?: CardImageUploader
+): Promise<string> {
+  if (!base64Image) return '';
+  if (isPrivate) {
+    throw new Error('私密卡片暂不支持本地图片，因为图片仓库是公开的');
+  }
+  if (!uploader) throw new Error('图片上传服务未配置');
+
+  const response = await uploader(base64Image, 'card');
+  const url = response.data?.url;
+
+  if (!response.success || !url) {
+    throw new Error(response.error || '图片上传失败，请稍后重试');
+  }
+
+  return url;
+}


### PR DESCRIPTION
## What changed

- upload locally selected card images through the existing authenticated Netlify image endpoint before creating the card
- store card images under `sunling/inspireplanet-assets/user_uploads/card/`
- persist only the returned HTTPS asset URL in the Supabase `cards.upload` field instead of base64 image data
- reject new non-HTTPS upload values in the card API so stale clients cannot put base64 images back into Supabase
- cap locally selected images at 4 MB and show the upload error returned by the server
- prevent private cards from publishing local images into the public asset repository
- keep image-search URLs and cards without local images unchanged

## Why

The card creator read local files as base64 and sent that full payload directly to the card API. The resulting image data was stored with the Supabase card record instead of using the existing GitHub-backed image upload flow.

This made card records unnecessarily large and bypassed the dedicated `inspireplanet-assets` repository.

## User impact

When a signed-in user creates a public card with a local image:

1. the image is uploaded to `inspireplanet-assets`
2. the returned raw GitHub URL is saved with the card
3. the card is created only after the image upload succeeds

If the image upload fails, the card is not created and the user sees the specific error. Private cards cannot attach local images because the asset repository is public.

This PR only affects new uploads; it does not migrate existing card images.

## Validation

- `vitest run`: 3 files, 11 tests passed
- TypeScript `tsc --noEmit` passed
- production Vite build passed
- remote branch compared with `main`: one commit, nine intended files